### PR TITLE
Added error model using PhotErr.

### DIFF
--- a/src/rail/creation/degradation/lsst_error_model.py
+++ b/src/rail/creation/degradation/lsst_error_model.py
@@ -1,0 +1,119 @@
+"""The LSST Model for photometric errors."""
+from dataclasses import MISSING
+from typing import get_origin, get_type_hints, get_args, Union
+
+from ceci.config import StageParameter as Param
+from photerr import LsstErrorModel as PhotErrErrorModel
+from photerr import LsstErrorParams as PhotErrErrorParams
+
+from rail.creation.degrader import Degrader
+
+
+def _resolve_type(val):
+    """Take the input type, and resolve it to its most basic value.
+
+    This is a helper function that helps extract the type information from
+    PhotErr in a way that Ceci likes (i.e. Ceci doesn't like parameterized
+    generic types).
+
+    E.g., it transforms dict[str, int] into dict, or
+
+    Parameters
+    ----------
+    val: Any
+        Some kind of type object. Intended to be a generic type, a
+        parameterized generic type, or a DataClass InitVar type.
+
+    Returns
+    -------
+    type
+        After the recursion ends, the generic resolved type is returned.
+    """
+    # If val has a type attribute (e.g. it's an InitVar),
+    # feed this type attribute back into this function
+    if hasattr(val, "type"):
+        return _resolve_type(val.type)
+
+    # If it's a Union
+    elif get_origin(val) is Union:
+        # Get the types inside the Union
+        type_tuple = get_args(val)
+
+        # Optional types are allowed.. but return type without None
+        if len(type_tuple) == 2 and type_tuple[1] is type(None):
+            return _resolve_type(type_tuple[0])
+        # Unions that aren't just Optional[type] are not allowed by Ceci
+        else:
+            raise TypeError("Sadly Ceci doesn't allow Union types.")
+
+    # If val is a parameterized generic type, remove the parameterization
+    elif get_origin(val) is not None:
+        return _resolve_type(get_origin(val))
+
+    # If none of the above apply, it should just be a type,
+    # so end the recursion and return the type
+    else:
+        return val
+
+
+class LSSTErrorModel(Degrader):
+    """The LSST Model for photometric errors.
+
+    This is a wrapper around the error model from PhotErr. The parameter
+    docstring below is dynamically added by the installed version of PhotErr:
+
+    """
+
+    # Dynamically add the parameter docstring from PhotErr
+    __doc__ += PhotErrErrorParams.__doc__
+
+    name = "LSSTErrorModel"
+    config_options = Degrader.config_options.copy()
+
+    # Now we want to copy all parameters from the installed PhotErr
+    # First, let's get a dict of all params, including the InitVars
+    _photerr_params = PhotErrErrorParams.__dataclass_fields__
+
+    # Now get the resolved types for every parameter
+    _photerr_types = {
+        key: _resolve_type(val)
+        for key, val in get_type_hints(PhotErrErrorParams).items()
+    }
+
+    # Finally, loop over all params to add to config_options
+    for key, val in _photerr_params.items():
+        # Get the default value
+        if val.default is MISSING:
+            default = val.default_factory()
+        else:
+            default = val.default
+
+        # Add this param to config_options
+        config_options[key] = Param(
+            _photerr_types[key],
+            default,
+            msg="See the main docstring for details about this parameter.",
+            required=False,
+        )
+
+    def __init__(self, args, comm=None):
+        """
+        Constructor
+
+        Does standard Degrader initialization and sets up the error model.
+        """
+        Degrader.__init__(self, args, comm=comm)
+        self.error_model = PhotErrErrorModel(
+            **{key: self.config[key] for key in self._photerr_params}
+        )
+
+    def run(self):
+        """Return pandas DataFrame with photometric errors."""
+        # Load the input catalog
+        data = self.get_data("input")
+
+        # Add photometric errors
+        obsData = self.error_model(data, random_state=self.config.seed)
+
+        # Return the new catalog
+        self.add_data("output", obsData)

--- a/src/rail/creation/degradation/lsst_error_model.py
+++ b/src/rail/creation/degradation/lsst_error_model.py
@@ -1,63 +1,10 @@
 """The LSST Model for photometric errors."""
-from dataclasses import MISSING, InitVar
-from typing import Union, get_args, get_origin, get_type_hints
+from dataclasses import MISSING
 
 from ceci.config import StageParameter as Param
 from photerr import LsstErrorModel as PhotErrErrorModel
 from photerr import LsstErrorParams as PhotErrErrorParams
 from rail.creation.degrader import Degrader
-
-# Add a dummy __call__ to InitVar. This is a hack to get around
-# not being able to get_type_hint on InitVars with older python
-if getattr(InitVar, "__call__", None) is None:
-    setattr(InitVar, "__call__", lambda *args, **kwargs: None)
-
-
-def _resolve_type(val):
-    """Take the input type, and resolve it to its most basic value.
-
-    This is a helper function that helps extract the type information from
-    PhotErr in a way that Ceci likes (i.e. Ceci doesn't like parameterized
-    generic types).
-
-    E.g., it transforms dict[str, int] into dict, or
-
-    Parameters
-    ----------
-    val: Any
-        Some kind of type object. Intended to be a generic type, a
-        parameterized generic type, or a DataClass InitVar type.
-
-    Returns
-    -------
-    type
-        After the recursion ends, the generic resolved type is returned.
-    """
-    # If val has a type attribute (e.g. it's an InitVar),
-    # feed this type attribute back into this function
-    if hasattr(val, "type"):
-        return _resolve_type(val.type)
-
-    # If it's a Union
-    elif get_origin(val) is Union:
-        # Get the types inside the Union
-        type_tuple = get_args(val)
-
-        # Optional types are allowed.. but return type without None
-        if len(type_tuple) == 2 and type_tuple[1] is type(None):
-            return _resolve_type(type_tuple[0])
-        # Unions that aren't just Optional[type] are not allowed by Ceci
-        else:
-            raise TypeError("Sadly Ceci doesn't allow Union types.")
-
-    # If val is a parameterized generic type, remove the parameterization
-    elif get_origin(val) is not None:
-        return _resolve_type(get_origin(val))
-
-    # If none of the above apply, it should just be a type,
-    # so end the recursion and return the type
-    else:
-        return val
 
 
 class LSSTErrorModel(Degrader):
@@ -74,17 +21,8 @@ class LSSTErrorModel(Degrader):
     name = "LSSTErrorModel"
     config_options = Degrader.config_options.copy()
 
-    # Now we want to copy all parameters from the installed PhotErr
-    # First, let's get a dict of all params, including the InitVars
+    # Dynamically add all parameters from PhotErr
     _photerr_params = PhotErrErrorParams.__dataclass_fields__
-
-    # Now get the resolved types for every parameter
-    _photerr_types = {
-        key: _resolve_type(val)
-        for key, val in get_type_hints(PhotErrErrorParams).items()
-    }
-
-    # Finally, loop over all params to add to config_options
     for key, val in _photerr_params.items():
         # Get the default value
         if val.default is MISSING:
@@ -94,8 +32,8 @@ class LSSTErrorModel(Degrader):
 
         # Add this param to config_options
         config_options[key] = Param(
-            _photerr_types[key],
-            default,
+            None,  # Let PhotErr handle type checking
+            default,  
             msg="See the main docstring for details about this parameter.",
             required=False,
         )

--- a/src/rail/creation/degradation/lsst_error_model.py
+++ b/src/rail/creation/degradation/lsst_error_model.py
@@ -1,12 +1,16 @@
 """The LSST Model for photometric errors."""
 from dataclasses import MISSING, InitVar
-from typing import get_origin, get_type_hints, get_args, Union
+from typing import Union, get_args, get_origin, get_type_hints
 
 from ceci.config import StageParameter as Param
 from photerr import LsstErrorModel as PhotErrErrorModel
 from photerr import LsstErrorParams as PhotErrErrorParams
-
 from rail.creation.degrader import Degrader
+
+# Add a dummy __call__ to InitVar. This is a hack to get around
+# not being able to get_type_hint on InitVars with older python
+if getattr(InitVar, "__call__", None) is None:
+    setattr(InitVar, "__call__", lambda *args, **kwargs: None)
 
 
 def _resolve_type(val):
@@ -73,11 +77,6 @@ class LSSTErrorModel(Degrader):
     # Now we want to copy all parameters from the installed PhotErr
     # First, let's get a dict of all params, including the InitVars
     _photerr_params = PhotErrErrorParams.__dataclass_fields__
-
-    # Add a dummy __call__ to InitVar. This is a hack to get around
-    # not being able to get_type_hint on InitVars with older python
-    if getattr(InitVar, "__call__", None) is None:
-        InitVar.__call__ = lambda *args, **kwargs: None
 
     # Now get the resolved types for every parameter
     _photerr_types = {

--- a/src/rail/creation/degradation/lsst_error_model.py
+++ b/src/rail/creation/degradation/lsst_error_model.py
@@ -1,5 +1,5 @@
 """The LSST Model for photometric errors."""
-from dataclasses import MISSING
+from dataclasses import MISSING, InitVar
 from typing import get_origin, get_type_hints, get_args, Union
 
 from ceci.config import StageParameter as Param
@@ -73,6 +73,11 @@ class LSSTErrorModel(Degrader):
     # Now we want to copy all parameters from the installed PhotErr
     # First, let's get a dict of all params, including the InitVars
     _photerr_params = PhotErrErrorParams.__dataclass_fields__
+
+    # Add a dummy __call__ to InitVar. This is a hack to get around
+    # not being able to get_type_hint on InitVars with older python
+    if getattr(InitVar, "__call__", None) is None:
+        InitVar.__call__ = lambda *args, **kwargs: None
 
     # Now get the resolved types for every parameter
     _photerr_types = {


### PR DESCRIPTION
## Change Description

This PR addresses [this ticket](https://github.com/LSSTDESC/rail_astro_tools/issues/3), by moving the `LSSTErrorModel` from rail_base to this repo, and removing the explicit error model implementation by just wrapping the error model in PhotErr.

Once this PR is merged, we need to merge two other PRs:
- [this PR](https://github.com/LSSTDESC/rail_base/pull/35) removes the old error model from `rail_base`
- [this PR](https://github.com/LSSTDESC/rail/pull/60) updates the example notebooks in `rail`