### PR TITLE
Issue/15/obscond input

### DIFF
--- a/src/rail/creation/degradation/observing_condition_degrader.py
+++ b/src/rail/creation/degradation/observing_condition_degrader.py
@@ -326,9 +326,7 @@ class ObsCondition(Degrader):
         assign the pixels to the input catalog
         check if catalogue contains position information;
         if so, assign according to ra, dec;
-        for objects outside the survey mask, assign nan # make sure it won't cause problem
         else, assign randomly.
-
         """
         pixels = self.maps["pixels"]
         if "weight" in list((self.maps).keys()):
@@ -336,9 +334,30 @@ class ObsCondition(Degrader):
             weights = weights / sum(weights)
         else:
             weights = None
-        assigned_pix = self.rng.choice(pixels, size=len(catalog), replace=True, p=weights)
+
+        if "renameDict" in self.maps.keys() and set(['ra','dec']).issubset(list(self.maps["renameDict"].keys())):
+            # if catalog contains ra, dec, but needs renaming
+            rakey=self.maps["renameDict"]['ra']
+            deckey=self.maps["renameDict"]['dec']
+            assigned_pix=hp.ang2pix(self.config["nside"], catalog[rakey].to_numpy(), catalog[deckey].to_numpy(), lonlat=True)            
+        elif set(['ra','dec']).issubset(catalog.columns):
+            # if catalog contains ra, dec, and no renaming
+            assigned_pix=hp.ang2pix(self.config["nside"], catalog['ra'].to_numpy(), catalog['dec'].to_numpy(), lonlat=True)
+        else:
+            # if catalog doesn't contain position information 
+            print("No ra, dec found in catalogue, randomly assign pixels with weights.")
+            assigned_pix = self.rng.choice(pixels, size=len(catalog), replace=True, p=weights)
+            
+        # this is the case where there are objects outside the footprint\
+        if not (np.in1d(assigned_pix, pixels)==True).all():
+            # flag all those pixels into -99
+            print("Warning: objects found outside given mask, pixel assigned=-99. These objects will be assigned with defualt error from LSST error model!")
+            ind=np.in1d(assigned_pix, pixels)
+            assigned_pix[~ind]=-99
+        
         # make it a DataFrame object
         assigned_pix = pd.DataFrame(assigned_pix, columns=["pixel"])
+        # attach pixels to the catalogue
         catalog = pd.concat([catalog, assigned_pix], axis=1)
 
         return catalog
@@ -408,16 +427,23 @@ class ObsCondition(Degrader):
             # loop over each pixel
             pixel_cat_list = []
             for pixel, pixel_cat in catalog.groupby("pixel"):
-                # get the observing conditions for this pixel
-                obs_conditions = self.get_pixel_conditions(pixel)
                 
-                # apply MW extinction if supplied, 
-                # replace the Mag column with reddened magnitudes:
-                if "EBV" in self.maps.keys():
-                    pixel_cat = self.apply_galactic_extinction(pixel, pixel_cat)
+                # first, check if pixel is -99 - these objects have default obs_conditions:
+                if pixel==-99:
+                    # creating the error model for this pixel
+                    errorModel = LsstErrorModel()
+                
+                else:            
+                    # get the observing conditions for this pixel
+                    obs_conditions = self.get_pixel_conditions(pixel)
 
-                # creating the error model for this pixel
-                errorModel = LsstErrorModel(**obs_conditions)
+                    # apply MW extinction if supplied, 
+                    # replace the Mag column with reddened magnitudes:
+                    if "EBV" in self.maps.keys():
+                        pixel_cat = self.apply_galactic_extinction(pixel, pixel_cat)
+
+                    # creating the error model for this pixel
+                    errorModel = LsstErrorModel(**obs_conditions)
 
                 # calculate the error model for this pixel
                 obs_cat = errorModel(pixel_cat, random_state=self.rng)

--- a/src/rail/creation/degradation/observing_condition_degrader.py
+++ b/src/rail/creation/degradation/observing_condition_degrader.py
@@ -324,6 +324,11 @@ class ObsCondition(Degrader):
     def assign_pixels(self, catalog: pd.DataFrame) -> pd.DataFrame:
         """
         assign the pixels to the input catalog
+        check if catalogue contains position information;
+        if so, assign according to ra, dec;
+        for objects outside the survey mask, assign nan # make sure it won't cause problem
+        else, assign randomly.
+
         """
         pixels = self.maps["pixels"]
         if "weight" in list((self.maps).keys()):

--- a/src/rail/creation/degradation/observing_condition_degrader.py
+++ b/src/rail/creation/degradation/observing_condition_degrader.py
@@ -348,13 +348,18 @@ class ObsCondition(Degrader):
             print("No ra, dec found in catalogue, randomly assign pixels with weights.")
             assigned_pix = self.rng.choice(pixels, size=len(catalog), replace=True, p=weights)
             
+            # in this case, also attach the ra, dec columns in the data:
+            ra, dec=hp.pix2ang(self.config["nside"],assigned_pix,lonlat=True)
+            skycoord = pd.DataFrame(np.c_[ra,dec], columns=["ra","decl"])
+            catalog = pd.concat([catalog, skycoord], axis=1)
+            
         # this is the case where there are objects outside the footprint\
         if not (np.in1d(assigned_pix, pixels)==True).all():
             # flag all those pixels into -99
             print("Warning: objects found outside given mask, pixel assigned=-99. These objects will be assigned with defualt error from LSST error model!")
             ind=np.in1d(assigned_pix, pixels)
             assigned_pix[~ind]=-99
-        
+               
         # make it a DataFrame object
         assigned_pix = pd.DataFrame(assigned_pix, columns=["pixel"])
         # attach pixels to the catalogue

--- a/src/rail/creation/degradation/observing_condition_degrader.py
+++ b/src/rail/creation/degradation/observing_condition_degrader.py
@@ -382,7 +382,11 @@ class ObsCondition(Degrader):
         ebvvec = self.maps["EBV"][ind]
 
         if "renameDict" in self.maps.keys():
-            bands = self.maps["renameDict"]
+            # in case renameDict contains other things than bands
+            bands={}
+            for b in ["u","g","r","i","z","y"]:
+                if b in list(self.maps["renameDict"].keys()):
+                    bands[b] = self.maps["renameDict"][b]
         elif "renameDict" not in self.maps.keys():
             bands = {
                 "u":"u",

--- a/tests/astro_tools/test_degraders.py
+++ b/tests/astro_tools/test_degraders.py
@@ -265,12 +265,20 @@ def test_ObsCondition_empty_map_dict(data):
     os.remove(degrader1.get_output(degrader1.get_aliased_tag("output"), final_name=True))
     
 
-def test_ObsCondition_renameDict(data):
+def test_ObsCondition_renameDict(data_with_radec):
     """Test with renameDict included"""
-    degrader1 = ObsCondition.make_stage(random_seed=0, map_dict={"EBV": 0.0,"renameDict": {"u": "u"},})
+    degrader1 = ObsCondition.make_stage(random_seed=0, map_dict={"EBV": 0.0,"renameDict": {"u": "u", "ra": "ra", "dec":"dec"},})
 
     # make sure setting the same seeds yields the same output
-    degraded_data1 = degrader1(data).data
+    degraded_data1 = degrader1(data_with_radec).data
+
+    os.remove(degrader1.get_output(degrader1.get_aliased_tag("output"), final_name=True))
+    
+    
+def test_ObsCondition_data_with_radec(data_with_radec):
+    """Test with ra dec in data"""
+    degrader1 = ObsCondition.make_stage(random_seed=0, map_dict={"EBV": 0.0})
+    degraded_data1 = degrader1(data_with_radec).data
 
     os.remove(degrader1.get_output(degrader1.get_aliased_tag("output"), final_name=True))
 
@@ -290,10 +298,3 @@ def test_LSSTErrorModel_returns_correct_columns(data):
         assert f"{band}_err" in degraded_data.columns
     os.remove(degrader.get_output(degrader.get_aliased_tag("output"), final_name=True))
 
-
-def test_ObsCondition_data_with_radec(data_with_radec):
-    """Test with ra dec in data"""
-    degrader1 = ObsCondition.make_stage(random_seed=0, map_dict={"EBV": 0.0})
-    degraded_data1 = degrader1(data_with_radec).data
-
-    os.remove(degrader1.get_output(degrader1.get_aliased_tag("output"), final_name=True))

--- a/tests/astro_tools/test_degraders.py
+++ b/tests/astro_tools/test_degraders.py
@@ -62,8 +62,8 @@ def data_with_radec():
     rng = np.random.default_rng(0)
     x = rng.normal(loc=26, scale=1, size=(100, 7))
     # for simplicity we will not sample uniformly on sphere
-    ra = rng.uniform(low=0, high=360, size=(100,1))
-    dec = rng.uniform(low=-90, high=90, size=(100,1))
+    ra = rng.uniform(low=40, high=80, size=(100,1))
+    dec = rng.uniform(low=-50, high=-25, size=(100,1))
     # replace redshifts with reasonable values
     x[:, 0] = np.linspace(0, 2, x.shape[0])
     x=np.append(x, ra, axis=1)

--- a/tests/astro_tools/test_degraders.py
+++ b/tests/astro_tools/test_degraders.py
@@ -53,6 +53,26 @@ def data_forspec():
     df = pd.DataFrame(x, columns=["redshift", "u", "g", "r", "i", "z", "y"])
     return DS.add_data("data_forspec", df, TableHandle, path="dummy_forspec.pd")
 
+@pytest.fixture
+def data_with_radec():
+    DS = DATA_STORE()
+    DS.__class__.allow_overwrite = True
+
+    # generate random normal data
+    rng = np.random.default_rng(0)
+    x = rng.normal(loc=26, scale=1, size=(100, 7))
+    # for simplicity we will not sample uniformly on sphere
+    ra = rng.uniform(low=0, high=360, size=(100,1))
+    dec = rng.uniform(low=-90, high=90, size=(100,1))
+    # replace redshifts with reasonable values
+    x[:, 0] = np.linspace(0, 2, x.shape[0])
+    x=np.append(x, ra, axis=1)
+    x=np.append(x, dec, axis=1)
+
+    # return data in handle wrapping a pandas DataFrame
+    df = pd.DataFrame(x, columns=["redshift", "u", "g", "r", "i", "z", "y", "ra", "dec"])
+    return DS.add_data("data_with_radec", df, TableHandle, path="dummy_with_radec.pd")
+
 
 
 @pytest.mark.parametrize("pivot_redshift,errortype", [("fake", TypeError), (-1, ValueError)])
@@ -246,7 +266,7 @@ def test_ObsCondition_empty_map_dict(data):
     
 
 def test_ObsCondition_renameDict(data):
-    """Test with no renameDict included"""
+    """Test with renameDict included"""
     degrader1 = ObsCondition.make_stage(random_seed=0, map_dict={"EBV": 0.0,"renameDict": {"u": "u"},})
 
     # make sure setting the same seeds yields the same output
@@ -270,4 +290,10 @@ def test_LSSTErrorModel_returns_correct_columns(data):
         assert f"{band}_err" in degraded_data.columns
     os.remove(degrader.get_output(degrader.get_aliased_tag("output"), final_name=True))
 
-    
+
+def test_ObsCondition_data_with_radec(data_with_radec):
+    """Test with ra dec in data"""
+    degrader1 = ObsCondition.make_stage(random_seed=0, map_dict={"EBV": 0.0})
+    degraded_data1 = degrader1(data_with_radec).data
+
+    os.remove(degrader1.get_output(degrader1.get_aliased_tag("output"), final_name=True))

--- a/tests/astro_tools/test_degraders.py
+++ b/tests/astro_tools/test_degraders.py
@@ -138,8 +138,9 @@ def test_ObsCondition_returns_correct_shape(data):
     degrader = ObsCondition.make_stage()
 
     degraded_data = degrader(data).data
-
-    assert degraded_data.shape == (data.data.shape[0], 2 * data.data.shape[1])
+    
+    # columns added: pixel, ugrizyerrors, ra, dec
+    assert degraded_data.shape == (data.data.shape[0], 2 * data.data.shape[1] + 2)
     os.remove(degrader.get_output(degrader.get_aliased_tag("output"), final_name=True))
 
 


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
- [x] My PR includes a link to the issue that I am addressing #15 



## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->

Previously, I randomly assign each object with a pixel inside the mask for its observing condition. Here, I added an option in observing_condition_degrader to assign observing conditions based on the object's position if they are included in the catalogue. The default columns are `ra` and `dec` but they can also be changed by passing the column names in `renameDict`. If objects are found outside the mask, they have the default LSST 10 year survey condition from the error model. If `ra`, `dec` were not in the input catalogue, they will be attached based on the assigned pixels. This is for convenience of de-reddening or other operations that requires sky positions later.

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

