### PR TITLE
Change the base class of lsst_noise_model, grid_selection, and spectroscopic_degrader

### DIFF
--- a/src/rail/creation/degradation/grid_selection.py
+++ b/src/rail/creation/degradation/grid_selection.py
@@ -158,9 +158,15 @@ class GridSelection(Selector):
 
         ratio_list = []
         max_specz_list = []
+                
         for pix_x, pix_y in zip(pixels_x, pixels_y):
-            ratio_list.append(ratios[pix_y][pix_x])
-            max_specz_list.append(max_specz[pix_y][pix_x])
+            # cover the galaxy outside the grid of ratio
+            if (pix_x in [-1,ratios.shape[0]]) or (pix_y in [-1, ratios.shape[1]]):
+                ratio_list.append(0.0)
+                max_specz_list.append(99.0)
+            else:
+                ratio_list.append(ratios[pix_y][pix_x])
+                max_specz_list.append(max_specz[pix_y][pix_x])
 
         data_hsc_like['ratios'] = ratio_list
         data_hsc_like['max_specz'] = max_specz_list

--- a/src/rail/creation/degradation/grid_selection.py
+++ b/src/rail/creation/degradation/grid_selection.py
@@ -213,8 +213,13 @@ class GridSelection(Selector):
             else:  # pragma: no cover
                 for j in range(int(number_to_keep) + 1):
                     keep_inds.append(indices_to_list[j])
-
+        
+        finalcut = data_hsc_like_redshift_cut.loc[keep_inds, :]
+        finalcut = finalcut[finalcut['redshift'] > 0]
+        
+        final_keep_inds = np.array(finalcut.index)
+        
         total_mask = np.zeros(len(data), dtype=bool)
-        total_mask[keep_inds] = True
+        total_mask[final_keep_inds] = True
 
         return total_mask

--- a/src/rail/creation/degradation/photerr_demo.ipynb
+++ b/src/rail/creation/degradation/photerr_demo.ipynb
@@ -1,0 +1,238 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2610a0f0-0c71-4401-896f-734442bcd66d",
+   "metadata": {},
+   "source": [
+    "## Photometric error stage demo\n",
+    "\n",
+    "author: Tianqing Zhang, John-Franklin Crenshaw\n",
+    "\n",
+    "This notebook demonstrate the use of `rail.creation.degradation.photometric_errors`, which adds column for the  photometric noise to the catalog based on the package PhotErr developed by John-Franklin Crenshaw. The RAIL stage PhotoErrorModel inherit from the Noisifier base classes, and the LSST, Roman, Euclid child classes inherit from the PhotoErrorModel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7a6adc3-68e8-4a1d-842f-bfb0960a1c4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from rail.creation.degradation.photometric_errors import LSSTErrorModel\n",
+    "from rail.creation.degradation.photometric_errors import RomanErrorModel\n",
+    "from rail.creation.degradation.photometric_errors import EuclidErrorModel\n",
+    "\n",
+    "from rail.core.data import PqHandle\n",
+    "from rail.core.stage import RailStage\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6912a740-31ea-4987-b06d-81ff17cd895a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DS = RailStage.data_store\n",
+    "DS.__class__.allow_overwrite = True\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a282c2ed-141b-4507-8254-dc8fbc9864dc",
+   "metadata": {},
+   "source": [
+    "### Create a random catalog with ugrizy+YJHF bands as the the true input"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1078bc2a-fc54-41c3-bd30-6c447bb971d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = np.random.normal(23, 3, size = (1000,10))\n",
+    "\n",
+    "data_df = pd.DataFrame(data=data,    # values\n",
+    "            columns=['u', 'g', 'r', 'i', 'z', 'y', 'Y', 'J', 'H', 'F'])\n",
+    "data_truth = PqHandle('input')\n",
+    "data_truth.set_data(data_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1da27deb-d167-4f38-8c59-f270184d6ab3",
+   "metadata": {},
+   "source": [
+    "### The LSST error model adds noise to the optical bands"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5f4862a-0621-46d4-8901-7e84b461c424",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errorModel_lsst = LSSTErrorModel.make_stage(name=\"error_model\")\n",
+    "\n",
+    "samples_w_errs = errorModel_lsst(data_truth)\n",
+    "samples_w_errs()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6282c42e-1a6f-480a-aa2b-817bd30d372f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(5, 4), dpi=100)\n",
+    "\n",
+    "for band in \"ugrizy\":\n",
+    "    # pull out the magnitudes and errors\n",
+    "    mags = samples_w_errs.data[band].to_numpy()\n",
+    "    errs = samples_w_errs.data[band + \"_err\"].to_numpy()\n",
+    "\n",
+    "    # sort them by magnitude\n",
+    "    mags, errs = mags[mags.argsort()], errs[mags.argsort()]\n",
+    "\n",
+    "    # plot errs vs mags\n",
+    "    ax.plot(mags, errs, label=band)\n",
+    "\n",
+    "ax.legend()\n",
+    "ax.set(xlabel=\"Magnitude (AB)\", ylabel=\"Error (mags)\")\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50927ccb-4492-4bdd-a29b-0907704b2c59",
+   "metadata": {},
+   "source": [
+    "### The Roman error model adds noise to the infrared bands"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d484a34b-cf10-45bd-8571-b78dc1818180",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errorModel_Roman = RomanErrorModel.make_stage(name=\"error_model\")\n",
+    "\n",
+    "samples_w_errs_roman = errorModel_Roman(data_truth)\n",
+    "samples_w_errs_roman()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a12362dc-0689-43f3-b990-edff734010bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(5, 4), dpi=100)\n",
+    "\n",
+    "for band in \"YJHF\":\n",
+    "    # pull out the magnitudes and errors\n",
+    "    mags = samples_w_errs_roman.data[band].to_numpy()\n",
+    "    errs = samples_w_errs_roman.data[band + \"_err\"].to_numpy()\n",
+    "\n",
+    "    # sort them by magnitude\n",
+    "    mags, errs = mags[mags.argsort()], errs[mags.argsort()]\n",
+    "\n",
+    "    # plot errs vs mags\n",
+    "    ax.plot(mags, errs, label=band)\n",
+    "\n",
+    "ax.legend()\n",
+    "ax.set(xlabel=\"Magnitude (AB)\", ylabel=\"Error (mags)\")\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "359de4ad-a47c-4dc5-8c81-53aeb92bdf42",
+   "metadata": {},
+   "source": [
+    "### The Euclid error model adds noise to YJH bands"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "775d0a23-7435-4b01-83db-2234c3d24f57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errorModel_Euclid = EuclidErrorModel.make_stage(name=\"error_model\")\n",
+    "\n",
+    "samples_w_errs_Euclid = errorModel_Euclid(data_truth)\n",
+    "samples_w_errs_Euclid()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7fcfe07a-5571-4dd3-8ad0-358964c1d493",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(5, 4), dpi=100)\n",
+    "\n",
+    "for band in \"YJH\":\n",
+    "    # pull out the magnitudes and errors\n",
+    "    mags = samples_w_errs_Euclid.data[band].to_numpy()\n",
+    "    errs = samples_w_errs_Euclid.data[band + \"_err\"].to_numpy()\n",
+    "\n",
+    "    # sort them by magnitude\n",
+    "    mags, errs = mags[mags.argsort()], errs[mags.argsort()]\n",
+    "\n",
+    "    # plot errs vs mags\n",
+    "    ax.plot(mags, errs, label=band)\n",
+    "\n",
+    "ax.legend()\n",
+    "ax.set(xlabel=\"Magnitude (AB)\", ylabel=\"Error (mags)\")\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "268b3d37-b7fd-4ac1-8457-2104a87c9e6d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "rail_env",
+   "language": "python",
+   "name": "rail_env"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/rail/creation/degradation/photometric_errors.py
+++ b/src/rail/creation/degradation/photometric_errors.py
@@ -56,7 +56,7 @@ class PhotoErrorModel(Noisifier):
         """
         Noisifier.__init__(self, args, comm=comm)
         
-    def initNoiseModel(self):
+    def _initNoiseModel(self):
         """
         Initialize the noise model by the peNoiseModel
         """
@@ -64,7 +64,7 @@ class PhotoErrorModel(Noisifier):
             **{key: self.config[key] for key in self._photerr_params}
         )
         
-    def addNoise(self, noiseModel):
+    def _addNoise(self):
         
         """
         Add noise to the input catalog
@@ -74,14 +74,14 @@ class PhotoErrorModel(Noisifier):
         data = self.get_data("input")
 
         # Add photometric errors
-        obsData = noiseModel(data, random_state=self.config.seed)
+        obsData = self.noiseModel(data, random_state=self.config.seed)
         
         # Return the new catalog
         self.add_data("output", obsData)
  
         
 class LSSTErrorModel(PhotoErrorModel):
-    
+
     """
     The LSST Error model, defined by peLsstErrorParams and peLsstErrorModel
     """

--- a/src/rail/creation/degradation/photometric_errors.py
+++ b/src/rail/creation/degradation/photometric_errors.py
@@ -15,12 +15,17 @@ class PhotoErrorModel(Noisifier):
 
     This is a wrapper around the error model from PhotErr. The parameter
     docstring below is dynamically added by the installed version of PhotErr:
-
+    
+    
     """
     
     name = "PhotoErrorModel"
     
     def set_params(self, peparams):
+        """
+        Set the photometric error parameters from photerr to 
+        the ceci config
+        """
         PhotErrErrorParams = peparams
                 
         config_options = Noisifier.config_options.copy()
@@ -52,11 +57,18 @@ class PhotoErrorModel(Noisifier):
         Noisifier.__init__(self, args, comm=comm)
         
     def initNoiseModel(self):
+        """
+        Initialize the noise model by the peNoiseModel
+        """
         self.noiseModel = self.peNoiseModel(
             **{key: self.config[key] for key in self._photerr_params}
         )
         
     def addNoise(self, noiseModel):
+        
+        """
+        Add noise to the input catalog
+        """
         
         # Load the input catalog
         data = self.get_data("input")
@@ -66,20 +78,18 @@ class PhotoErrorModel(Noisifier):
         
         # Return the new catalog
         self.add_data("output", obsData)
-        
-        print('addNoise is ran')
-        
+ 
         
 class LSSTErrorModel(PhotoErrorModel):
+    
+    """
+    The LSST Error model, defined by peLsstErrorParams and peLsstErrorModel
+    """
     
     name = "LSSTErrorModel"
     
     def __init__(self, args, comm=None):
-        """
-        Constructor
 
-        Does standard Degrader initialization and sets up the error model.
-        """
         PhotoErrorModel.__init__(self, args, comm=comm)
         
         self.set_params(peLsstErrorParams)   
@@ -90,14 +100,14 @@ class LSSTErrorModel(PhotoErrorModel):
         
 class RomanErrorModel(PhotoErrorModel):
     
+    """
+    The Roman Error model, defined by peRomanErrorParams and peRomanErrorModel
+    """
+    
     name = "RomanErrorModel"
     
     def __init__(self, args, comm=None):
-        """
-        Constructor
 
-        Does standard Degrader initialization and sets up the error model.
-        """
         PhotoErrorModel.__init__(self, args, comm=comm)
         
         self.set_params(peRomanErrorParams)    
@@ -107,14 +117,14 @@ class RomanErrorModel(PhotoErrorModel):
         
 class EuclidErrorModel(PhotoErrorModel):
     
+    """
+    The Roman Error model, defined by peRomanErrorParams and peRomanErrorModel
+    """
+    
     name = "EuclidErrorModel"
     
     def __init__(self, args, comm=None):
-        """
-        Constructor
 
-        Does standard Degrader initialization and sets up the error model.
-        """
         PhotoErrorModel.__init__(self, args, comm=comm)
         
         self.set_params(peEuclidErrorParams)    

--- a/src/rail/creation/degradation/photometric_errors.py
+++ b/src/rail/creation/degradation/photometric_errors.py
@@ -6,6 +6,8 @@ from photerr import LsstErrorModel as peLsstErrorModel
 from photerr import LsstErrorParams as peLsstErrorParams
 from photerr import RomanErrorModel as peRomanErrorModel
 from photerr import RomanErrorParams as peRomanErrorParams
+from photerr import EuclidErrorModel as peEuclidErrorModel
+from photerr import EuclidErrorParams as peEuclidErrorParams
 from rail.creation.noisifier import Noisifier
 
 class PhotoErrorModel(Noisifier):
@@ -15,6 +17,8 @@ class PhotoErrorModel(Noisifier):
     docstring below is dynamically added by the installed version of PhotErr:
 
     """
+    
+    name = "PhotoErrorModel"
     
     def set_params(self, peparams):
         PhotErrErrorParams = peparams
@@ -47,7 +51,10 @@ class PhotoErrorModel(Noisifier):
         """
         Noisifier.__init__(self, args, comm=comm)
         
-
+    def initNoiseModel(self):
+        self.noiseModel = self.peNoiseModel(
+            **{key: self.config[key] for key in self._photerr_params}
+        )
         
     def addNoise(self, noiseModel):
         
@@ -58,7 +65,6 @@ class PhotoErrorModel(Noisifier):
         obsData = noiseModel(data, random_state=self.config.seed)
         
         # Return the new catalog
-        
         self.add_data("output", obsData)
         
         print('addNoise is ran')
@@ -67,8 +73,6 @@ class PhotoErrorModel(Noisifier):
 class LSSTErrorModel(PhotoErrorModel):
     
     name = "LSSTErrorModel"
-#     PhotErrErrorParams = peLsstErrorParams
-#     PhotoErrorModel.define_default_params(peLsstErrorParams)
     
     def __init__(self, args, comm=None):
         """
@@ -78,22 +82,15 @@ class LSSTErrorModel(PhotoErrorModel):
         """
         PhotoErrorModel.__init__(self, args, comm=comm)
         
+        self.set_params(peLsstErrorParams)   
+        self.peNoiseModel = peLsstErrorModel
         
-        self.set_params(peLsstErrorParams)
-        self.initNoiseModel()
-        
-        
-    def initNoiseModel(self):
-        self.noiseModel = peLsstErrorModel(
-            **{key: self.config[key] for key in self._photerr_params}
-        )
+
         
         
 class RomanErrorModel(PhotoErrorModel):
     
     name = "RomanErrorModel"
-    # PhotoErrorModel.PhotErrErrorParams = peRomanErrorParams
-    # PhotoErrorModel.define_default_params()
     
     def __init__(self, args, comm=None):
         """
@@ -103,11 +100,22 @@ class RomanErrorModel(PhotoErrorModel):
         """
         PhotoErrorModel.__init__(self, args, comm=comm)
         
-        self.set_params(peRomanErrorParams)
-        self.initNoiseModel()
+        self.set_params(peRomanErrorParams)    
+        self.peNoiseModel = peRomanErrorModel
+
+                
         
+class EuclidErrorModel(PhotoErrorModel):
+    
+    name = "EuclidErrorModel"
+    
+    def __init__(self, args, comm=None):
+        """
+        Constructor
+
+        Does standard Degrader initialization and sets up the error model.
+        """
+        PhotoErrorModel.__init__(self, args, comm=comm)
         
-    def initNoiseModel(self):
-        self.noiseModel = peRomanErrorModel(
-            **{key: self.config[key] for key in self._photerr_params}
-        )
+        self.set_params(peEuclidErrorParams)    
+        self.peNoiseModel = peEuclidErrorModel

--- a/src/rail/creation/degradation/photometric_errors.py
+++ b/src/rail/creation/degradation/photometric_errors.py
@@ -1,4 +1,9 @@
-"""The LSST Model for photometric errors."""
+"""
+The Photometric error Model LSST, Roman, and Euclid. Based on photometric 
+error models defined in the package photerr
+
+Author: John Franklin Crenshaw, Tianqing Zhang
+"""
 from dataclasses import MISSING
 
 from ceci.config import StageParameter as Param

--- a/src/rail/creation/degradation/photometric_errors.py
+++ b/src/rail/creation/degradation/photometric_errors.py
@@ -16,32 +16,6 @@ class PhotoErrorModel(Noisifier):
 
     """
     
-#     @classmethod
-#     def define_default_params(cls, peparams):
-        
-        
-#         PhotErrErrorParams = peparams
-                
-#         config_options = Noisifier.config_options.copy()
-
-#         # Dynamically add all parameters from PhotErr
-#         _photerr_params = PhotErrErrorParams.__dataclass_fields__
-#         cls._photerr_params = _photerr_params
-#         for key, val in _photerr_params.items():
-#             # Get the default value
-#             if val.default is MISSING:
-#                 default = val.default_factory()
-#             else:
-#                 default = val.default
-
-#             # Add this param to config_options
-#             cls.config_options[key] = Param(
-#                 None,  # Let PhotErr handle type checking
-#                 default,  
-#                 msg="See the main docstring for details about this parameter.",
-#                 required=False,
-#             )
-        
     def set_params(self, peparams):
         PhotErrErrorParams = peparams
                 

--- a/src/rail/creation/degradation/photometric_errors.py
+++ b/src/rail/creation/degradation/photometric_errors.py
@@ -1,0 +1,139 @@
+"""The LSST Model for photometric errors."""
+from dataclasses import MISSING
+
+from ceci.config import StageParameter as Param
+from photerr import LsstErrorModel as peLsstErrorModel
+from photerr import LsstErrorParams as peLsstErrorParams
+from photerr import RomanErrorModel as peRomanErrorModel
+from photerr import RomanErrorParams as peRomanErrorParams
+from rail.creation.noisifier import Noisifier
+
+class PhotoErrorModel(Noisifier):
+    """The Base Model for photometric errors.
+
+    This is a wrapper around the error model from PhotErr. The parameter
+    docstring below is dynamically added by the installed version of PhotErr:
+
+    """
+    
+#     @classmethod
+#     def define_default_params(cls, peparams):
+        
+        
+#         PhotErrErrorParams = peparams
+                
+#         config_options = Noisifier.config_options.copy()
+
+#         # Dynamically add all parameters from PhotErr
+#         _photerr_params = PhotErrErrorParams.__dataclass_fields__
+#         cls._photerr_params = _photerr_params
+#         for key, val in _photerr_params.items():
+#             # Get the default value
+#             if val.default is MISSING:
+#                 default = val.default_factory()
+#             else:
+#                 default = val.default
+
+#             # Add this param to config_options
+#             cls.config_options[key] = Param(
+#                 None,  # Let PhotErr handle type checking
+#                 default,  
+#                 msg="See the main docstring for details about this parameter.",
+#                 required=False,
+#             )
+        
+    def set_params(self, peparams):
+        PhotErrErrorParams = peparams
+                
+        config_options = Noisifier.config_options.copy()
+
+        # Dynamically add all parameters from PhotErr
+        _photerr_params = PhotErrErrorParams.__dataclass_fields__
+        self._photerr_params = _photerr_params
+        for key, val in _photerr_params.items():
+            # Get the default value
+            if val.default is MISSING:
+                default = val.default_factory()
+            else:
+                default = val.default
+
+            # Add this param to config_options
+            self.config[key] = Param(
+                None,  # Let PhotErr handle type checking
+                default,  
+                msg="See the main docstring for details about this parameter.",
+                required=False,
+            )
+        
+    def __init__(self, args, comm=None):
+        """
+        Constructor
+
+        Does standard Degrader initialization and sets up the error model.
+        """
+        Noisifier.__init__(self, args, comm=comm)
+        
+
+        
+    def addNoise(self, noiseModel):
+        
+        # Load the input catalog
+        data = self.get_data("input")
+
+        # Add photometric errors
+        obsData = noiseModel(data, random_state=self.config.seed)
+        
+        # Return the new catalog
+        
+        self.add_data("output", obsData)
+        
+        print('addNoise is ran')
+        
+        
+class LSSTErrorModel(PhotoErrorModel):
+    
+    name = "LSSTErrorModel"
+#     PhotErrErrorParams = peLsstErrorParams
+#     PhotoErrorModel.define_default_params(peLsstErrorParams)
+    
+    def __init__(self, args, comm=None):
+        """
+        Constructor
+
+        Does standard Degrader initialization and sets up the error model.
+        """
+        PhotoErrorModel.__init__(self, args, comm=comm)
+        
+        
+        self.set_params(peLsstErrorParams)
+        self.initNoiseModel()
+        
+        
+    def initNoiseModel(self):
+        self.noiseModel = peLsstErrorModel(
+            **{key: self.config[key] for key in self._photerr_params}
+        )
+        
+        
+class RomanErrorModel(PhotoErrorModel):
+    
+    name = "RomanErrorModel"
+    # PhotoErrorModel.PhotErrErrorParams = peRomanErrorParams
+    # PhotoErrorModel.define_default_params()
+    
+    def __init__(self, args, comm=None):
+        """
+        Constructor
+
+        Does standard Degrader initialization and sets up the error model.
+        """
+        PhotoErrorModel.__init__(self, args, comm=comm)
+        
+        self.set_params(peRomanErrorParams)
+        self.initNoiseModel()
+        
+        
+    def initNoiseModel(self):
+        self.noiseModel = peRomanErrorModel(
+            **{key: self.config[key] for key in self._photerr_params}
+        )

--- a/tests/astro_tools/test_degraders.py
+++ b/tests/astro_tools/test_degraders.py
@@ -102,11 +102,11 @@ def test_GridSelection_bad_params(percentile_cut, redshift_cut, errortype):
 
 
 def test_GridSelection_returns_correct_shape(data):
-    """Make sure returns 2 more columns, fewer rows"""
+    """Make sure returns same number of columns, fewer rows"""
     degrader = GridSelection.make_stage(pessimistic_redshift_cut=1.0)
     degraded_data = degrader(data).data
     assert degraded_data.shape[0] < data.data.shape[0]
-    assert degraded_data.shape[1] == data.data.shape[1] - 1
+    assert degraded_data.shape[1] == data.data.shape[1] 
     os.remove(degrader.get_output(degrader.get_aliased_tag("output"), final_name=True))
 
     

--- a/tests/astro_tools/test_degraders.py
+++ b/tests/astro_tools/test_degraders.py
@@ -84,7 +84,7 @@ def test_InvRedshiftIncompleteness_bad_params(pivot_redshift, errortype):
 
 def test_InvRedshiftIncompleteness_returns_correct_shape(data):
     """Make sure returns same number of columns, fewer rows"""
-    degrader = InvRedshiftIncompleteness.make_stage(pivot_redshift=1.0)
+    degrader = InvRedshiftIncompleteness.make_stage(pivot_redshift=1.0, seed = 12345)
     degraded_data = degrader(data).data
     assert degraded_data.shape[0] < data.data.shape[0]
     assert degraded_data.shape[1] == data.data.shape[1]


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

In this PR I have 
1. added a general photometric error model class, which is an expansion of the old LSST error model class with the inclusion of the Roman and Euclid error model. 
2. Change the base class of the grid_selection from degrader to selector, implement the _select function, and return a flag with the same length as that of the input data. I have make sure that the notebook in rail hub imports the new class and runs okay without the change needed. 



## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
