### PR TITLE
fix photometric_errors subclasses to parse paramters after dynamicall…

### DIFF
--- a/src/rail/creation/degraders/photometric_errors.py
+++ b/src/rail/creation/degraders/photometric_errors.py
@@ -55,7 +55,14 @@ class PhotoErrorModel(Noisifier):
             )
 
     def reload_pars(self, args):
-        self.load_configs(args)
+        """ This is needed b/c the parameters are dynamically defined, 
+        so we have to reload them _after_ then have been defined """
+        copy_args = args.copy()
+        if isinstance(args, dict):
+            copy_args['config'] = args
+        else:  # pragma: no cover
+            copy_args['config'] = vars(args)            
+        self.load_configs(copy_args)
         self._io_checked = False
         self.check_io()
         

--- a/src/rail/creation/degraders/photometric_errors.py
+++ b/src/rail/creation/degraders/photometric_errors.py
@@ -45,7 +45,7 @@ class PhotoErrorModel(Noisifier):
                 default = val.default_factory()
             else:
                 default = val.default
-
+                
             # Add this param to config_options
             self.config[key] = Param(
                 None,  # Let PhotErr handle type checking
@@ -53,6 +53,11 @@ class PhotoErrorModel(Noisifier):
                 msg="See the main docstring for details about this parameter.",
                 required=False,
             )
+
+    def reload_pars(self, args):
+        self.load_configs(args)
+        self._io_checked = False
+        self.check_io()
         
     def _initNoiseModel(self):
         """
@@ -67,7 +72,6 @@ class PhotoErrorModel(Noisifier):
         """
         Add noise to the input catalog
         """
-        
         # Load the input catalog
         data = self.get_data("input")
 
@@ -95,9 +99,8 @@ class LSSTErrorModel(PhotoErrorModel):
         super().__init__(args, **kwargs)
         
         self.set_params(peLsstErrorParams)   
+        self.reload_pars(args)
         self.peNoiseModel = peLsstErrorModel
-        
-
         
         
 class RomanErrorModel(PhotoErrorModel):
@@ -113,6 +116,7 @@ class RomanErrorModel(PhotoErrorModel):
         super().__init__(args, **kwargs)
         
         self.set_params(peRomanErrorParams)    
+        self.reload_pars(args)
         self.peNoiseModel = peRomanErrorModel
 
                 
@@ -130,4 +134,5 @@ class EuclidErrorModel(PhotoErrorModel):
         super().__init__(args, **kwargs)
         
         self.set_params(peEuclidErrorParams)    
+        self.reload_pars(args)
         self.peNoiseModel = peEuclidErrorModel


### PR DESCRIPTION
…y defining them

## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
