### PR TITLE
get PhotoErrorModel.reload_pars to play nice with ceci

### DIFF
--- a/src/rail/creation/degraders/photometric_errors.py
+++ b/src/rail/creation/degraders/photometric_errors.py
@@ -47,21 +47,27 @@ class PhotoErrorModel(Noisifier):
                 default = val.default
                 
             # Add this param to config_options
-            self.config[key] = Param(
+            # Use setattr() becuase ceci.StageConfig has
+            # implemented __setitem__ to just set the value
+            # rather than add the parameters
+            param = Param(
                 None,  # Let PhotErr handle type checking
                 default,  
                 msg="See the main docstring for details about this parameter.",
                 required=False,
             )
+            setattr(self.config, key, param)
 
     def reload_pars(self, args):
         """ This is needed b/c the parameters are dynamically defined, 
         so we have to reload them _after_ then have been defined """
-        copy_args = args.copy()
         if isinstance(args, dict):
+            # coming from python, add 'config' to the configuration
+            copy_args = args.copy()
             copy_args['config'] = args
         else:  # pragma: no cover
-            copy_args['config'] = vars(args)            
+            # coming from cli, just convert to a dict
+            copy_args = vars(args).copy()
         self.load_configs(copy_args)
         self._io_checked = False
         self.check_io()

--- a/src/rail/pipelines/degradation/apply_phot_errors.py
+++ b/src/rail/pipelines/degradation/apply_phot_errors.py
@@ -13,6 +13,7 @@ from rail.core.stage import RailStage, RailPipeline
 import ceci
 
 from rail.core.utils import RAILDIR
+from rail.utils import catalog_utils
 
 if 'PZ_DUSTMAP_DIR' not in os.environ:
     os.environ['PZ_DUSTMAP_DIR'] = '.'
@@ -62,6 +63,7 @@ class ApplyPhotErrorsPipeline(RailPipeline):
                 name=f'error_model_{key}',
                 connections=dict(input=previous_stage.io.output),
                 hdf5_groupname='',
+                renameDict=catalog_utils.CatalogConfigBase.active_class().band_name_dict(),
             )
             self.add_stage(the_error_model)
             previous_stage = the_error_model

--- a/src/rail/pipelines/degradation/truth_to_observed.py
+++ b/src/rail/pipelines/degradation/truth_to_observed.py
@@ -13,7 +13,7 @@ from rail.core.stage import RailStage, RailPipeline
 import ceci
 
 from rail.core.utils import RAILDIR
-
+from rail.utils import catalog_utils
 from rail.creation.degraders.unrec_bl_model import UnrecBlModel
 
 from .spectroscopic_selection_pipeline import SELECTORS, CommonConfigParams
@@ -60,6 +60,7 @@ class TruthToObservedPipeline(RailPipeline):
                 name=f'error_model_{key}',
                 connections=dict(input=previous_stage.io.output),
                 hdf5_groupname='',
+                renameDict=catalog_utils.CatalogConfigBase.active_class().band_name_dict(),
             )
             self.add_stage(the_error_model)
             previous_stage = the_error_model


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
