### PR TITLE
reformat a few docstrings to work with sphinx

### DIFF
--- a/src/rail/creation/degraders/grid_selection.py
+++ b/src/rail/creation/degraders/grid_selection.py
@@ -16,24 +16,24 @@ class GridSelection(Selector):
     into training and application samples. Option to implement a color-based redshift cut off in each pixel.
     Option of further degrading the training sample by limiting it to galaxies less than a redshift cutoff by specifying redshift_cut.
 
-    Parameters
-    ----------
-    color_redshift_cut: True or false, implements color-based redshift cut. Default is True.
-        If True, ratio_file must include second key called 'data' with magnitudes, colors and spec-z from the spectroscopic sample.
-    percentile_cut: If using color-based redshift cut, percentile in spec-z above which redshifts will be cut from training sample. Default is 99.0
-    scaling_factor: Enables the user to adjust the ratios by this factor to change the overall number of galaxies kept.  For example, if you wish
-        to generate 100,00 galaxies but only 50,000 are selected by default, then you can adjust factor up by a factor of 2 to return more galaixes.
-    redshift_cut: redshift above which all galaxies will be removed from training sample. Default is 100
-    ratio_file: hdf5 file containing an array of spectroscpic vs. photometric galaxies in each pixel. Default is hsc_ratios.hdf5 for an HSC based selection
-    settings_file: pickled dictionary containing information about colors and magnitudes used in defining the pixels. Dictionary must include the following keys:
-      'x_band_1': string, this is the band used for the magnitude in the color magnitude diagram. Default for HSC is 'i'.
-      'x_band_2': string, this is the redder band used for the color in the color magnitude diagram.
-      if x_band_2 string is not set to '' then the grid is assumed to be over color and x axis color is set to x_band_1 - x_band_2, default is ''.
-      'y_band_1': string, this is the bluer band used for the color in the color magnitude grid. Default for HSC is 'g'.
-      'y_band_2': string, this is the redder band used for the color in the color magnitude diagram.
-      if y_band_2 is not set to '' then the y-band is assumed to be over color and is set to y_band_1 - y_band 2.
-      'x_limits': 2-element list, this is a list of the lower and upper limits of the magnitude. Default for HSC is [13, 16],
-      'y_limits': 2-element list, this is a list of the lower and upper limits of the color. Default for HSC is [-2, 6]}
+    .. code-block:: text
+
+        color_redshift_cut: True or false, implements color-based redshift cut. Default is True.
+            If True, ratio_file must include second key called 'data' with magnitudes, colors and spec-z from the spectroscopic sample.
+        percentile_cut: If using color-based redshift cut, percentile in spec-z above which redshifts will be cut from training sample. Default is 99.0
+        scaling_factor: Enables the user to adjust the ratios by this factor to change the overall number of galaxies kept.  For example, if you wish
+            to generate 100,00 galaxies but only 50,000 are selected by default, then you can adjust factor up by a factor of 2 to return more galaixes.
+        redshift_cut: redshift above which all galaxies will be removed from training sample. Default is 100
+        ratio_file: hdf5 file containing an array of spectroscpic vs. photometric galaxies in each pixel. Default is hsc_ratios.hdf5 for an HSC based selection
+        settings_file: pickled dictionary containing information about colors and magnitudes used in defining the pixels. Dictionary must include the following keys:
+            'x_band_1': string, this is the band used for the magnitude in the color magnitude diagram. Default for HSC is 'i'.
+            'x_band_2': string, this is the redder band used for the color in the color magnitude diagram.
+            if x_band_2 string is not set to '' then the grid is assumed to be over color and x axis color is set to x_band_1 - x_band_2, default is ''.
+            'y_band_1': string, this is the bluer band used for the color in the color magnitude grid. Default for HSC is 'g'.
+            'y_band_2': string, this is the redder band used for the color in the color magnitude diagram.
+            if y_band_2 is not set to '' then the y-band is assumed to be over color and is set to y_band_1 - y_band 2.
+            'x_limits': 2-element list, this is a list of the lower and upper limits of the magnitude. Default for HSC is [13, 16],
+            'y_limits': 2-element list, this is a list of the lower and upper limits of the color. Default for HSC is [-2, 6]}
 
     NOTE: the default 'HSC' grid file, located in rail/examples_data/creation_data/data/hsc_ratios_and_specz.hdf5, is based on data from the
     Second HSC Data Release, details of which can be found here:

--- a/src/rail/creation/degraders/observing_condition_degrader.py
+++ b/src/rail/creation/degraders/observing_condition_degrader.py
@@ -19,43 +19,40 @@ class ObsCondition(Noisifier):
     using input survey condition maps. The error is based on the
     LSSTErrorModel from the PhotErr python package.
 
-    Parameters
-    ----------
-    nside: int, optional
-        nside used for the HEALPIX maps.
-    mask: str, optional
-        Path to the mask covering the survey
-        footprint in HEALPIX format. Notice that
-        all negative values will be set to zero.
-    weight: str, optional
-        Path to the weights HEALPIX format, used
-        to assign sample galaxies to pixels. Default
-        is weight="", which uses uniform weighting.
-    tot_nVis_flag: bool, optional
-        If any map for nVisYr are provided, this flag
-        indicates whether the map shows the total number of
-        visits in nYrObs (tot_nVis_flag=True), or the average
-        number of visits per year (tot_nVis_flag=False). The
-        default is set to True.
-    random_seed: int, optional
-        A random seed for reproducibility.
-    map_dict: dict, optional
-        A dictionary that contains the paths to the
-        survey condition maps in HEALPIX format. This dictionary
-        uses the same arguments as LSSTErrorModel (from PhotErr).
-        The following arguments, if supplied, may contain either
-        a single number (as in the case of LSSTErrorModel), or a path:
-        [m5, nVisYr, airmass, gamma, msky, theta, km, tvis, EBV]
-        For the following keys:
-        [m5, nVisYr, gamma, msky, theta, km]
-        numbers/paths for specific bands must be passed.
-        Example:
-        {"m5": {"u": path, ...}, "theta": {"u": path, ...},}
-        Other LSSTErrorModel parameters can also be passed
-        in this dictionary (e.g. a necessary one may be [nYrObs]
-        for the survey condition maps).
-        If any argument is not passed, the default value in
-        PhotErr's LsstErrorModel is adopted.
+    .. code-block:: text
+
+        mask: str, optional
+            Path to the mask covering the survey
+            footprint in HEALPIX format. Notice that
+            all negative values will be set to zero.
+        weight: str, optional
+            Path to the weights HEALPIX format, used
+            to assign sample galaxies to pixels. Default
+            is weight="", which uses uniform weighting.
+            tot_nVis_flag: bool, optional
+            If any map for nVisYr are provided, this flag
+            indicates whether the map shows the total number of
+            visits in nYrObs (tot_nVis_flag=True), or the average
+            number of visits per year (tot_nVis_flag=False). The
+            default is set to True.
+        map_dict: dict, optional
+            A dictionary that contains the paths to the
+            survey condition maps in HEALPIX format. This dictionary
+            uses the same arguments as LSSTErrorModel (from PhotErr).
+            The following arguments, if supplied, may contain either
+            a single number (as in the case of LSSTErrorModel), or a path:
+            [m5, nVisYr, airmass, gamma, msky, theta, km, tvis, EBV]
+            For the following keys:
+            [m5, nVisYr, gamma, msky, theta, km]
+            numbers/paths for specific bands must be passed.
+            Example:
+            {"m5": {"u": path, ...}, "theta": {"u": path, ...},}
+            Other LSSTErrorModel parameters can also be passed
+            in this dictionary (e.g. a necessary one may be [nYrObs]
+            or the survey condition maps).
+            If any argument is not passed, the default value in
+            PhotErr's LsstErrorModel is adopted.
+
 
     """
 

--- a/src/rail/creation/degraders/spectroscopic_degraders.py
+++ b/src/rail/creation/degraders/spectroscopic_degraders.py
@@ -13,9 +13,9 @@ class LineConfusion(Noisifier):
 
     .. code-block:: python
 
-       Example: degrader = LineConfusion(true_wavelen=3727,
-                                         wrong_wavelen=5007,
-                                         frac_wrong=0.05)
+       degrader = LineConfusion(true_wavelen=3727,
+                                wrong_wavelen=5007,
+                                frac_wrong=0.05)
 
     is a degrader that misidentifies 5% of OII lines (at 3727 angstroms)
     as OIII lines (at 5007 angstroms), which results in a larger
@@ -26,17 +26,6 @@ class LineConfusion(Noisifier):
     in a negative redshift, which can occur for low redshift galaxies when
     wrong_wavelen < true_wavelen.
 
-    Parameters
-    ----------
-    true_wavelen : positive float
-        The wavelength of the true emission line.
-        Wavelength unit assumed to be the same as wrong_wavelen.
-    wrong_wavelen : positive float
-        The wavelength of the wrong emission line, which is being confused
-        for the correct emission line.
-        Wavelength unit assumed to be the same as true_wavelen.
-    frac_wrong : float between zero and one
-        The fraction of galaxies with confused emission lines.
     """
 
     name = 'LineConfusion'
@@ -108,10 +97,6 @@ class InvRedshiftIncompleteness(Selector):
     p(z) = min(1, z_p/z),
     where z_p is the pivot redshift.
 
-    Parameters
-    ----------
-    pivot_redshift : positive float
-        The redshift at which the incompleteness begins.
     """
 
     name = 'InvRedshiftIncompleteness'

--- a/src/rail/creation/degraders/spectroscopic_selections.py
+++ b/src/rail/creation/degraders/spectroscopic_selections.py
@@ -12,28 +12,6 @@ from rail.utils.path_utils import RAILDIR
 class SpecSelection(Selector):
     """The super class of spectroscopic selections.
 
-    Parameters
-    ----------
-    N_tot : int
-        The total number of down-sampled, spec-selected galaxies. If N_tot is 
-        greater than the number of spec-sepected galaxies, then it will be 
-        ignored.
-    nondetect_val : float
-        The value to be removed for non detects
-    downsample : bool
-        If True, then downsample the pre-selected galaxies to N_tot galaxies.
-    success_rate_dir : string
-        The path to the success rate files
-    percentile_cut: int, default=100
-        If using color-based redshift cut, percentile in redshifts above which 
-        redshifts will be cut from the sample. Default is 100 (no cut).
-    colnames: dict
-        A dictionary that includes necessary columns (magnitudes, colors and 
-        redshift) for selection. For magnitudes, the keys are ugrizy; for 
-        colors, the keys are, for example, gr standing for g-r; for redshift, 
-        the key is 'redshift'.
-    random_seed : int
-        Random seed for reproducibility
     """
 
     name = "SpecSelection"

--- a/src/rail/creation/engines/gcr_engine.py
+++ b/src/rail/creation/engines/gcr_engine.py
@@ -11,16 +11,11 @@ class GCRCreator(Creator):
 
     For info on GCRCatalogs, see https://github.com/LSSTDESC/gcr-catalogs
 
-    Parameters
-    ----------
-    gcr_root_dir : str, default="/global/cfs/cdirs/lsst/shared"
-        The path to the GCR Catalogs.
-    catalog_name : str, default="cosmoDC2_v1.1.4_small"
-        The name of the GCR catalog to load. See https://github.com/LSSTDESC/gcr-catalogs/blob/master/examples/GCRCatalogs%20Demo.ipynb for how to get available options.
-    quantities : list, default=[redshift, mag_u_lsst, mag_g_lsst, ..., size_true, size_minor_true]
-        The quantities to query from the catalog. See https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/SCHEMA.md for all options.
-    filters : list, default=["mag_i_lsst < 26.5"]
-        Filters that are passed to the GCR Query.
+    See https://github.com/LSSTDESC/gcr-catalogs/blob/master/examples/GCRCatalogs%20Demo.ipynb
+    for how to get available options for catalog_name.
+
+    See https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/SCHEMA.md
+    for all options for quantities to query.
     """
 
     name = "GCRLoader"


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

Fixing docstrings so that they work with sphinx autodoc

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
