### PR TITLE
fix renameDict in obscondition

### DIFF
--- a/src/rail/creation/degraders/observing_condition_degrader.py
+++ b/src/rail/creation/degraders/observing_condition_degrader.py
@@ -136,11 +136,16 @@ class ObsCondition(Noisifier):
         # validate input parameters
         self._validate_obs_config()
 
+        # set renameDict in map_dict
+        if "renameDict" in self.config:
+            self.config['map_dict']['renameDict'] = self.config['renameDict']
+
         # initiate self.maps
         self.maps = {}
 
         # load the maps
         self._get_maps()
+
 
     def _validate_obs_config(self):
         """
@@ -465,7 +470,7 @@ class ObsCondition(Noisifier):
         """
         Initialise the error model: LSSTerrorModel
         """
-        self.default_errorModel = LsstErrorModel()
+        self.default_errorModel = LsstErrorModel(renameDict = self.config['renameDict'])
 
     def _addNoise(self):
         """
@@ -496,7 +501,7 @@ class ObsCondition(Noisifier):
 
                 # first, check if pixel is -99 - these objects have default obs_conditions:
                 if pixel == -99:
-                    # use the default error model for this pixel
+                    # use the default error model for this pixel, using the band names specified
                     errorModel = self.default_errorModel
 
                 else:

--- a/src/rail/creation/degraders/observing_condition_degrader.py
+++ b/src/rail/creation/degraders/observing_condition_degrader.py
@@ -470,7 +470,11 @@ class ObsCondition(Noisifier):
         """
         Initialise the error model: LSSTerrorModel
         """
-        self.default_errorModel = LsstErrorModel(renameDict = self.config['renameDict'])
+        if 'renameDict' not in self.config['map_dict'].keys():
+            renameDict=None
+        else:
+            renameDict = self.config['map_dict']['renameDict']
+        self.default_errorModel = LsstErrorModel(renameDict=renameDict)
 
     def _addNoise(self):
         """


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
The renameDict was not passed to ObsCondition stage correctly. This fixes this issue.

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
