### PR TITLE
Implement GaussianSkewtScatterSelector to emulate COSMOS-like photometric redshifts

### DIFF
--- a/src/rail/creation/degraders/cosmos_selector.py
+++ b/src/rail/creation/degraders/cosmos_selector.py
@@ -1,0 +1,1 @@
+/Users/jmyles/repositories/LSSTDESC/rail_base/src/rail/creation/selectors/cosmos_selector.py

--- a/src/rail/creation/degraders/cosmos_selector.py
+++ b/src/rail/creation/degraders/cosmos_selector.py
@@ -1,1 +1,215 @@
-/Users/jmyles/repositories/LSSTDESC/rail_base/src/rail/creation/selectors/cosmos_selector.py
+"""Add a bias to redshift using model parameters loaded from a CSV file."""
+
+
+from typing import Any
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from ceci.config import StageParameter as Param
+from scipy.stats import jf_skew_t
+
+from rail.creation.selector import Selector
+
+class COSMOSSelector(Selector):
+    """Add a column of random numbers to a dataframe"""
+
+    name = "COSMOSSelector"
+    entrypoint_function = "__call__"  # the user-facing science function for this class
+    interactive_function = "COSMOSSelector"
+    config_options = Selector.config_options.copy()
+    config_options.update(
+        col_name=Param(
+            str, "photoz_COSMOS", msg="Name of the column to make with mock photometric redshifts"
+        ),
+        col_name_mag_i=Param(
+            str, "mag_i", msg="Name of the i-band magnitude column"
+        ),
+        col_name_z=Param(
+            str, "z", msg="Name of the (true) redshift column"
+        ),
+        model_params_path=Param(
+            str, "cosmos.csv", msg="Path to CSV file with model parameters for Gaussian core and skew-t tail distribution components"
+        ),
+    )
+
+    def __init__(self, args: Any, **kwargs: Any) -> None:
+        """
+        Constructor
+        Does standard Selector initialization
+        """
+        Selector.__init__(self, args, **kwargs)
+
+    def _initNoiseModel(self) -> None:  # pragma: no cover
+        self._rng = np.random.default_rng(self.config.seed)
+
+    def _addNoise(self) -> None:  # pragma: no cover
+        self._addNoiseCOSMOS()
+
+    def _select(self) -> None:  # pragma: no cover
+        # for this selector, we currently don't actually select any rows
+        data = self.get_data("input")
+        selection_mask = np.ones(len(data), dtype=bool)
+
+        # for the COSMOS selector, emulate photo-z's
+        self._initNoiseModel()
+        self._addNoise()
+        return selection_mask
+    
+    def COSMOSSelector(self, sample: Any, seed: int | None = None, **kwargs: Any):
+        return self.__call__(sample, seed=seed, **kwargs)
+
+    def _resolve_model_path(self) -> Path:
+        path = Path(self.config.model_params_path).expanduser()
+        if path.exists():
+            return path
+        raise FileNotFoundError(f"photo-z bias model parameter file not found: {self.config.model_params_path}")
+
+    def _load_parametric_model(self) -> None:
+        ''' load model parameters from a csv file and convert to a dictionary '''
+        path = self._resolve_model_path()
+        df = pd.read_csv(path)
+
+        core = df[df["component"] == "gaussian_core"].copy()
+        tail = df[df["component"] == "skew_student_t_tail"].copy()
+
+        # Reconstruct bin edges and ordered bin-pairs
+        i_edges = np.unique(np.r_[core["i_bin_lo"].to_numpy(), core["i_bin_hi"].to_numpy()])
+        z_edges = np.unique(np.r_[core["z_bin_lo"].to_numpy(), core["z_bin_hi"].to_numpy()])
+        i_pairs = list(zip(i_edges[:-1], i_edges[1:]))
+        z_pairs = list(zip(z_edges[:-1], z_edges[1:]))
+
+        core["i_pair"] = list(zip(core["i_bin_lo"], core["i_bin_hi"]))
+        core["z_pair"] = list(zip(core["z_bin_lo"], core["z_bin_hi"]))
+
+        # Core component: make 2D lookup tables for parameters (ordered by i_pairs x z_pairs)
+        med_tbl = (core.pivot_table(index="i_pair", columns="z_pair", values="mu", aggfunc="first")
+                        .reindex(index=i_pairs, columns=z_pairs).to_numpy())
+        std_tbl = (core.pivot_table(index="i_pair", columns="z_pair", values="sigma", aggfunc="first")
+                        .reindex(index=i_pairs, columns=z_pairs).to_numpy())
+
+        # Tail component: make parameter arrays per i-bin
+        n_i = len(i_pairs)
+        f_tail  = np.zeros(n_i)
+        t_loc   = np.zeros(n_i)
+        t_scale = np.full(n_i, 0.2)
+        t_a     = np.full(n_i, 3.0)
+        t_b     = np.full(n_i, 3.0)
+
+        tail["i_pair"] = list(zip(tail["i_bin_lo"], tail["i_bin_hi"]))
+        i_pair_index = {p: i for i, p in enumerate(i_pairs)}
+        for _, r in tail.iterrows():
+            j = i_pair_index.get(r["i_pair"])
+            if j is None: 
+                continue
+            f_tail[j]  = float(r["f_tail"])
+            t_loc[j]   = float(r["tail_loc"])
+            t_scale[j] = float(r["tail_scale"])
+            t_a[j]     = float(r["tail_a"])
+            t_b[j]     = float(r["tail_b"])
+
+        self._cosmos_model = {
+            "mag_i_bin_edges": i_edges,
+            "z_bin_edges":     z_edges,
+            "bias_median_lookup_table": med_tbl,
+            "bias_std_lookup_table":    std_tbl,
+            "f_tail_by_mag_i":          f_tail,
+            "tail_loc_by_mag_i":        t_loc,
+            "tail_scale_by_mag_i":      t_scale,
+            "tail_a_by_mag_i":          t_a,
+            "tail_b_by_mag_i":          t_b,
+        }
+
+    def _sample_parametric_bias_model(
+        self,
+        data_i: np.ndarray,
+        data_z: np.ndarray,
+        target_mask: np.ndarray,
+    ) -> np.ndarray:
+        """Sample bias using a csv-configured Gaussian core + skewed Student-t tail."""
+        z_bias_samples = np.zeros_like(data_z)
+        if not np.any(target_mask):
+            return z_bias_samples
+
+        self._load_parametric_model()
+        model = self._cosmos_model
+
+        n_target = int(np.sum(target_mask))
+        target_i = data_i[target_mask]
+        target_z = data_z[target_mask]
+
+        # determine mag_i and z bin for each target galaxy
+        # if the target falls outside the bin edges, assign it to the nearest bin
+        target_mag_i_bin = np.digitize(target_i, model["mag_i_bin_edges"]) - 1
+        target_z_bin = np.digitize(target_z, model["z_bin_edges"]) - 1
+        target_mag_i_bin = np.clip(target_mag_i_bin, 0, model["bias_median_lookup_table"].shape[0] - 1)
+        target_z_bin = np.clip(target_z_bin, 0, model["bias_median_lookup_table"].shape[1] - 1)
+
+        # set component parameters for each target
+        target_mean_bias_component1 = model["bias_median_lookup_table"][target_mag_i_bin, target_z_bin]
+        target_std_bias_component1 = model["bias_std_lookup_table"][target_mag_i_bin, target_z_bin]
+        target_tail_prob = model["f_tail_by_mag_i"][target_mag_i_bin]
+
+        # Monte Carlo sampling to determine which component each galaxy belongs to.
+        u = self._rng.random(n_target)
+        is_tail = u < target_tail_prob
+        is_core = ~is_tail
+
+        # generate redshift bias for each galaxy based on its assigned component
+        target_bias = np.zeros(n_target)
+        # core component (Gaussian from Yin+25)
+        target_bias[is_core] = self._rng.normal(
+            loc=target_mean_bias_component1[is_core],
+            scale=target_std_bias_component1[is_core],
+        )
+        # tail component (skewed Student-t)
+        if np.any(is_tail):
+            idx_tail = target_mag_i_bin[is_tail]
+            tail_samples = np.empty(np.sum(is_tail))
+            # iterate over unique mag_i bins
+            for idx_ in np.unique(idx_tail):
+                in_mag = idx_tail == idx_
+                tail_samples[in_mag] = jf_skew_t.rvs(
+                    a=model["tail_a_by_mag_i"][idx_],
+                    b=model["tail_b_by_mag_i"][idx_],
+                    loc=model["tail_loc_by_mag_i"][idx_],
+                    scale=model["tail_scale_by_mag_i"][idx_],
+                    size=int(np.sum(in_mag)),
+                    random_state=self._rng,
+                )
+            target_bias[is_tail] = tail_samples
+        z_bias_samples[target_mask] = target_bias
+        return z_bias_samples
+
+    def _addNoiseCOSMOS(self) -> None:  # pragma: no cover
+        data = self.get_data("input")
+        data_i = np.asarray(data[self.config.col_name_mag_i])
+        data_z = np.asarray(data[self.config.col_name_z])
+
+        valid_target_mask = np.isfinite(data_i) & np.isfinite(data_z) & (data_z > 0)
+        z_bias_samples = self._sample_parametric_bias_model(
+            data_i=data_i,
+            data_z=data_z,
+            target_mask=valid_target_mask,
+        )
+        z_noisified = data_z + z_bias_samples
+
+        # Re-sample out-of-bounds mock redshifts up to 3 times.
+        invalid_mask = valid_target_mask & ((z_noisified < 0) | (z_noisified > 6))
+        for _ in range(3):
+            if not np.any(invalid_mask):
+                break
+            retry_bias = self._sample_parametric_bias_model(
+                data_i=data_i,
+                data_z=data_z,
+                target_mask=invalid_mask,
+            )
+            z_bias_samples[invalid_mask] = retry_bias[invalid_mask]
+            z_noisified = data_z + z_bias_samples
+            invalid_mask = valid_target_mask & ((z_noisified < 0) | (z_noisified > 6))
+
+        # Final clip after retries.
+        z_noisified = np.clip(z_noisified, 0, 6)
+
+        data[self.config.col_name] = z_noisified
+        return

--- a/src/rail/creation/degraders/gaussian_skewt_scatter_selector.py
+++ b/src/rail/creation/degraders/gaussian_skewt_scatter_selector.py
@@ -19,11 +19,11 @@ default_selector_model_dict = dict(mag_i_bin_edges = np.array([15.5, 22. , 23. ,
                                            [0.011, 0.019, 0.025, 0.036, 0.062, 0.062, 0.062, 0.062],
                                            [0.011, 0.022, 0.027, 0.044, 0.063, 0.115, 0.093, 0.074],
                                            [0.013, 0.023, 0.025, 0.051, 0.069, 0.12 , 0.103, 0.069]]),
-                                   f_tail_by_mag_i = np.array([0.088 , 0.1377, 0.4312, 0.01  ]),
-                                   tail_loc_by_mag_i = np.array([-0.0055,  0.1568,  0.2   , -0.02  ]),
-                                   tail_scale_by_mag_i = np.array([0.2041, 0.3522, 0.237 , 0.08  ]),
-                                   tail_a_by_mag_i = np.array([ 3.7662, 10.1149,  2.    ,  8.    ]),
-                                   tail_b_by_mag_i = np.array([ 4.    , 11.2095,  4.    ,  8.    ]))
+                                   f_tail_by_mag_i = np.array([0.088 , 0.1377, 0.4312, 0.4312  ]),
+                                   tail_loc_by_mag_i = np.array([-0.0055,  0.1568,  0.2   , 0.2  ]),
+                                   tail_scale_by_mag_i = np.array([0.2041, 0.3522, 0.237 , 0.237  ]),
+                                   tail_a_by_mag_i = np.array([ 3.7662, 10.1149,  2.    ,  2.    ]),
+                                   tail_b_by_mag_i = np.array([ 4.    , 11.2095,  4.    ,  4.    ]))
 
 class GaussianSkewtScatterSelector(Selector):
     """Add a mock photometric redshift column to a dataframe with a Gaussian + skew Student-t error model"""

--- a/src/rail/creation/degraders/gaussian_skewt_scatter_selector.py
+++ b/src/rail/creation/degraders/gaussian_skewt_scatter_selector.py
@@ -1,26 +1,40 @@
-"""Add a bias to redshift using model parameters loaded from a CSV file."""
+"""Add a bias to redshift using a Gaussian core + skewed Student-t tail error model."""
 
 
 from typing import Any
-from pathlib import Path
 
 import numpy as np
-import pandas as pd
 from ceci.config import StageParameter as Param
 from scipy.stats import jf_skew_t
 
 from rail.creation.selector import Selector
 
-class COSMOSSelector(Selector):
-    """Add a column of random numbers to a dataframe"""
+default_selector_model_dict = dict(mag_i_bin_edges = np.array([15.5, 22. , 23. , 24. , 29. ]),
+                                   z_bin_edges = np.array([0. , 0.3, 0.7, 1. , 1.5, 2. , 2.5, 3. , 4. ]),
+                                   bias_median_lookup_table = np.array([[ 0.   ,  0.002, -0.002,  0.001,  0.001,  0.001,  0.001,  0.001],
+                                           [ 0.   , -0.   , -0.002, -0.004,  0.01 ,  0.01 ,  0.01 ,  0.01 ],
+                                           [ 0.003, -0.   , -0.001, -0.006, -0.002,  0.024,  0.007,  0.   ],
+                                           [ 0.008, -0.005,  0.007, -0.015, -0.019,  0.017,  0.011,  0.   ]]),
+                                   bias_std_lookup_table = np.array([[0.01 , 0.02 , 0.026, 0.038, 0.038, 0.038, 0.038, 0.038],
+                                           [0.011, 0.019, 0.025, 0.036, 0.062, 0.062, 0.062, 0.062],
+                                           [0.011, 0.022, 0.027, 0.044, 0.063, 0.115, 0.093, 0.074],
+                                           [0.013, 0.023, 0.025, 0.051, 0.069, 0.12 , 0.103, 0.069]]),
+                                   f_tail_by_mag_i = np.array([0.088 , 0.1377, 0.4312, 0.01  ]),
+                                   tail_loc_by_mag_i = np.array([-0.0055,  0.1568,  0.2   , -0.02  ]),
+                                   tail_scale_by_mag_i = np.array([0.2041, 0.3522, 0.237 , 0.08  ]),
+                                   tail_a_by_mag_i = np.array([ 3.7662, 10.1149,  2.    ,  8.    ]),
+                                   tail_b_by_mag_i = np.array([ 4.    , 11.2095,  4.    ,  8.    ]))
 
-    name = "COSMOSSelector"
+class GaussianSkewtScatterSelector(Selector):
+    """Add a mock photometric redshift column to a dataframe with a Gaussian + skew Student-t error model"""
+
+    name = "GaussianSkewtScatterSelector"
     entrypoint_function = "__call__"  # the user-facing science function for this class
-    interactive_function = "COSMOSSelector"
+    interactive_function = "GaussianSkewtScatterSelector"
     config_options = Selector.config_options.copy()
     config_options.update(
         col_name=Param(
-            str, "photoz_COSMOS", msg="Name of the column to make with mock photometric redshifts"
+            str, "photoz_mock", msg="Name of the mock photometric redshift column to make"
         ),
         col_name_mag_i=Param(
             str, "mag_i", msg="Name of the i-band magnitude column"
@@ -28,8 +42,8 @@ class COSMOSSelector(Selector):
         col_name_z=Param(
             str, "z", msg="Name of the (true) redshift column"
         ),
-        model_params_path=Param(
-            str, "cosmos.csv", msg="Path to CSV file with model parameters for Gaussian core and skew-t tail distribution components"
+        selector_model_dict=Param(
+            dict, default_selector_model_dict, msg="Dictionary of model parameters for Gaussian core and skew-t tail distribution components"
         ),
     )
 
@@ -42,83 +56,23 @@ class COSMOSSelector(Selector):
 
     def _initNoiseModel(self) -> None:  # pragma: no cover
         self._rng = np.random.default_rng(self.config.seed)
+        self._model = self.config.selector_model_dict
 
     def _addNoise(self) -> None:  # pragma: no cover
-        self._addNoiseCOSMOS()
+        self._addNoiseGaussianSkewtScatter()
 
     def _select(self) -> None:  # pragma: no cover
         # for this selector, we currently don't actually select any rows
         data = self.get_data("input")
         selection_mask = np.ones(len(data), dtype=bool)
 
-        # for the COSMOS selector, emulate photo-z's
+        # for the GaussianSkewtScatter selector, emulate photo-z's
         self._initNoiseModel()
         self._addNoise()
         return selection_mask
     
-    def COSMOSSelector(self, sample: Any, seed: int | None = None, **kwargs: Any):
+    def GaussianSkewtScatterSelector(self, sample: Any, seed: int | None = None, **kwargs: Any):
         return self.__call__(sample, seed=seed, **kwargs)
-
-    def _resolve_model_path(self) -> Path:
-        path = Path(self.config.model_params_path).expanduser()
-        if path.exists():
-            return path
-        raise FileNotFoundError(f"photo-z bias model parameter file not found: {self.config.model_params_path}")
-
-    def _load_parametric_model(self) -> None:
-        ''' load model parameters from a csv file and convert to a dictionary '''
-        path = self._resolve_model_path()
-        df = pd.read_csv(path)
-
-        core = df[df["component"] == "gaussian_core"].copy()
-        tail = df[df["component"] == "skew_student_t_tail"].copy()
-
-        # Reconstruct bin edges and ordered bin-pairs
-        i_edges = np.unique(np.r_[core["i_bin_lo"].to_numpy(), core["i_bin_hi"].to_numpy()])
-        z_edges = np.unique(np.r_[core["z_bin_lo"].to_numpy(), core["z_bin_hi"].to_numpy()])
-        i_pairs = list(zip(i_edges[:-1], i_edges[1:]))
-        z_pairs = list(zip(z_edges[:-1], z_edges[1:]))
-
-        core["i_pair"] = list(zip(core["i_bin_lo"], core["i_bin_hi"]))
-        core["z_pair"] = list(zip(core["z_bin_lo"], core["z_bin_hi"]))
-
-        # Core component: make 2D lookup tables for parameters (ordered by i_pairs x z_pairs)
-        med_tbl = (core.pivot_table(index="i_pair", columns="z_pair", values="mu", aggfunc="first")
-                        .reindex(index=i_pairs, columns=z_pairs).to_numpy())
-        std_tbl = (core.pivot_table(index="i_pair", columns="z_pair", values="sigma", aggfunc="first")
-                        .reindex(index=i_pairs, columns=z_pairs).to_numpy())
-
-        # Tail component: make parameter arrays per i-bin
-        n_i = len(i_pairs)
-        f_tail  = np.zeros(n_i)
-        t_loc   = np.zeros(n_i)
-        t_scale = np.full(n_i, 0.2)
-        t_a     = np.full(n_i, 3.0)
-        t_b     = np.full(n_i, 3.0)
-
-        tail["i_pair"] = list(zip(tail["i_bin_lo"], tail["i_bin_hi"]))
-        i_pair_index = {p: i for i, p in enumerate(i_pairs)}
-        for _, r in tail.iterrows():
-            j = i_pair_index.get(r["i_pair"])
-            if j is None: 
-                continue
-            f_tail[j]  = float(r["f_tail"])
-            t_loc[j]   = float(r["tail_loc"])
-            t_scale[j] = float(r["tail_scale"])
-            t_a[j]     = float(r["tail_a"])
-            t_b[j]     = float(r["tail_b"])
-
-        self._cosmos_model = {
-            "mag_i_bin_edges": i_edges,
-            "z_bin_edges":     z_edges,
-            "bias_median_lookup_table": med_tbl,
-            "bias_std_lookup_table":    std_tbl,
-            "f_tail_by_mag_i":          f_tail,
-            "tail_loc_by_mag_i":        t_loc,
-            "tail_scale_by_mag_i":      t_scale,
-            "tail_a_by_mag_i":          t_a,
-            "tail_b_by_mag_i":          t_b,
-        }
 
     def _sample_parametric_bias_model(
         self,
@@ -126,13 +80,12 @@ class COSMOSSelector(Selector):
         data_z: np.ndarray,
         target_mask: np.ndarray,
     ) -> np.ndarray:
-        """Sample bias using a csv-configured Gaussian core + skewed Student-t tail."""
+        """Sample bias using a Gaussian core + skewed Student-t tail."""
         z_bias_samples = np.zeros_like(data_z)
         if not np.any(target_mask):
             return z_bias_samples
 
-        self._load_parametric_model()
-        model = self._cosmos_model
+        model = self.config.selector_model_dict
 
         n_target = int(np.sum(target_mask))
         target_i = data_i[target_mask]
@@ -181,7 +134,7 @@ class COSMOSSelector(Selector):
         z_bias_samples[target_mask] = target_bias
         return z_bias_samples
 
-    def _addNoiseCOSMOS(self) -> None:  # pragma: no cover
+    def _addNoiseGaussianSkewtScatter(self) -> None:  # pragma: no cover
         data = self.get_data("input")
         data_i = np.asarray(data[self.config.col_name_mag_i])
         data_z = np.asarray(data[self.config.col_name_z])


### PR DESCRIPTION
This PR implements an example selector to emulate COSMOS photometric redshifts with biases relative to the truth. The biased values are drawn from a model with parameters stored in a csv file. 

This linked [example notebook](https://gist.github.com/jtmyles/b16e0aa5c8f89c48248fadf73aa22335) shows the selector using model parameters fit on zCOSMOS data. The mock photo-z residuals mostly reproduce the residuals seen in the test dataset. 

The model implemented contains an inner Gaussian core distribution from Yin+2025 and a broader tail distribution set by a skewed t-distribution. Samples from the model are re-drawn up to three times for bias values that yield photo-z outside the bounds [0,6]. 

This model is trained on a sample of biased spectroscopic data, so cannot be expected to represent the full variance in the overall population. Better motivated alternatives to this simplistic two component model could reproduce the observed data distribution better, but since this data distribution is expected to underestimate the actual variance of the population, improving the model without appropriately inflating the model variance may simply amount to more overfitting to the biased spectroscopic data. The small test set used for the default model has fewer than 25 spectra fainter than i > 23, so the default model is especially limited at those magnitudes. 

The csv file stores component parameters for a given i-band magnitude and z bin. The cosmos_selector.py file re-organizes this into a dictionary for sampling. If anyone has suggestions on improving the way the data is stored and loaded please let me know. 