### PR TITLE
parameter renames for astro tools

### DIFF
--- a/src/rail/creation/degraders/grid_selection.py
+++ b/src/rail/creation/degraders/grid_selection.py
@@ -67,7 +67,7 @@ class GridSelection(Selector):
         redshift_cut=Param(float, 100.0, msg="cut redshifts above this value"),
         ratio_file=Param(str, def_ratio_file, msg="path to ratio file"),
         settings_file=Param(str, def_set_file, msg="path to pickled parameters file"),
-        random_seed=Param(int, 12345, msg="random seed for reproducibility"),
+        seed=Param(int, 12345, msg="random seed for reproducibility"),
         scaling_factor=Param(
             float,
             1.588,
@@ -93,7 +93,7 @@ class GridSelection(Selector):
         If using a color-based redshift cut, galaxies with redshifts > the percentile cut are removed from the sample
         before making the random selection.
         """
-        rng = np.random.default_rng(seed=self.config.random_seed)
+        rng = np.random.default_rng(seed=self.config.seed)
 
         data = self.get_data("input")
         with open(self.config.settings_file, "rb") as handle:

--- a/src/rail/creation/degraders/observing_condition_degrader.py
+++ b/src/rail/creation/degraders/observing_condition_degrader.py
@@ -86,7 +86,7 @@ class ObsCondition(Noisifier):
             True,
             msg="flag indicating whether nVisYr is the total or average per year if supplied.",
         ),
-        random_seed=Param(int, 42, msg="random seed for reproducibility"),
+        seed=Param(int, 42, msg="random seed for reproducibility"),
         map_dict=Param(
             dict,
             {
@@ -480,7 +480,7 @@ class ObsCondition(Noisifier):
         """
         Run the noisifier.
         """
-        self.rng = np.random.default_rng(seed=self.config["random_seed"])
+        self.rng = np.random.default_rng(seed=self.config["seed"])
 
         catalog = self.get_data("input", allow_missing=True)
 
@@ -550,7 +550,7 @@ class ObsCondition(Noisifier):
 
         printMsg += f"tot_nVis_flag = {self.config['tot_nVis_flag']}, \n"
 
-        printMsg += f"random_seed = {self.config['random_seed']}, \n"
+        printMsg += f"random_seed = {self.config['seed']}, \n"
 
         printMsg += "map_dict contains the following items: \n"
 

--- a/src/rail/creation/degraders/spectroscopic_selections.py
+++ b/src/rail/creation/degraders/spectroscopic_selections.py
@@ -4,6 +4,7 @@ import os
 
 import numpy as np
 from ceci.config import StageParameter as Param
+from rail.core.common_params import SHARED_PARAMS
 from rail.creation.selector import Selector
 from rail.utils.path_utils import RAILDIR
 from scipy.interpolate import interp1d
@@ -17,12 +18,12 @@ class SpecSelection(Selector):
     interactive_function = "spec_selection"
     config_options = Selector.config_options.copy()
     config_options.update(
-        N_tot=Param(int, 10000, msg="Number of selected sources"),
-        nondetect_val=Param(float, 99.0, msg="value to be removed for non detects"),
+        n_tot=Param(int, 10000, msg="Number of selected sources"),
+        nondetect_val=SHARED_PARAMS,
         downsample=Param(
             bool,
             True,
-            msg="If true, downsample the selected sources into a total number of N_tot",
+            msg="If true, downsample the selected sources into a total number of n_tot",
         ),
         success_rate_dir=Param(
             str,
@@ -44,7 +45,7 @@ class SpecSelection(Selector):
                 colors, the keys are, for example, gr standing for g-r; for redshift,
                 the key is 'redshift'""",
         ),
-        random_seed=Param(int, 42, msg="random seed for reproducibility"),
+        seed=Param(int, 42, msg="random seed for reproducibility"),
     )
 
     def __init__(self, args, **kwargs):
@@ -55,7 +56,7 @@ class SpecSelection(Selector):
 
     def _validate_settings(self):
         """Validate all the settings."""
-        if self.config.N_tot < 0:
+        if self.config.n_tot < 0:
             raise ValueError(
                 "Total number of selected sources must be a " "positive integer."
             )
@@ -105,22 +106,22 @@ class SpecSelection(Selector):
             self.mask &= ~np.isnan(data[colname])
             self.mask &= np.isfinite(data[colname])
 
-    def downsampling_N_tot(self):
+    def downsampling_n_tot(self):
         """Randomly sample down the objects to a given number of data objects."""
-        N_tot = self.config.N_tot
-        N_selected = np.count_nonzero(self.mask)
-        if N_tot > N_selected:
+        n_tot = self.config.n_tot
+        n_selected = np.count_nonzero(self.mask)
+        if n_tot > n_selected:
             print(
-                "Warning: N_tot is greater than the size of spec-selected "
+                "Warning: n_tot is greater than the size of spec-selected "
                 + "sample ("
-                + str(N_selected)
+                + str(n_selected)
                 + "). The spec-selected sample "
                 + "is returned."
             )
             return
         else:
             idx_selected = np.where(self.mask)[0]
-            idx_keep = self.rng.choice(idx_selected, replace=False, size=N_tot)
+            idx_keep = self.rng.choice(idx_selected, replace=False, size=n_tot)
             # create a mask with only those entries enabled that have been
             # selected
             mask = np.zeros_like(self.mask)
@@ -130,7 +131,7 @@ class SpecSelection(Selector):
 
     def _select(self):
         """Run the selection."""
-        self.rng = np.random.default_rng(seed=self.config.random_seed)
+        self.rng = np.random.default_rng(seed=self.config.seed)
         # get the bands and bandNames present in the data
         data = self.get_data("input", allow_missing=True)
         self.validate_colnames(data)
@@ -138,7 +139,7 @@ class SpecSelection(Selector):
         self.invalid_cut(data)
         self.selection(data)
         if self.config.downsample is True:
-            self.downsampling_N_tot()
+            self.downsampling_n_tot()
 
         return self.mask
 

--- a/src/rail/tools/photometry_tools.py
+++ b/src/rail/tools/photometry_tools.py
@@ -407,7 +407,7 @@ class LSSTFluxToMagConverter(RailStage):
             default="mag_err_{band}_lsst",
             msg="Template for magnitude error column names",
         ),
-        copy_cols=Param(dict, default={}, msg="Map of other columns to copy"),
+        copy_col_dict=Param(dict, default={}, msg="Map of other columns to copy"),
         mag_offset=Param(float, default=31.4, msg="Magntidue offset value"),
     )
 
@@ -439,7 +439,7 @@ class LSSTFluxToMagConverter(RailStage):
                     data[flux_col_name].values, data[flux_err_col_name].values
                 )
             )
-        for key, val in self.config.copy_cols.items():  # pragma: no cover
+        for key, val in self.config.copy_col_dict.items():  # pragma: no cover
             out_data[key] = data[val].values
         self.add_data("output", out_data)
 

--- a/tests/astro_tools/test_core.py
+++ b/tests/astro_tools/test_core.py
@@ -50,7 +50,7 @@ def test_dereddener():
     test_data = tables_io.read(testFile)
 
     fluxToMag = LSSTFluxToMagConverter.make_stage(
-        name="flux2mag", copy_cols=dict(ra="ra", dec="decl")
+        name="flux2mag", copy_col_dict=dict(ra="ra", dec="decl")
     )
 
     is_temp_dir = False

--- a/tests/astro_tools/test_degraders.py
+++ b/tests/astro_tools/test_degraders.py
@@ -311,7 +311,7 @@ def test_SpecSelection(data):
 
 
 
-def test_SpecSelection_low_N_tot(data_forspec):
+def test_SpecSelection_low_n_tot(data_forspec):
     bands = ["u", "g", "r", "i", "z", "y"]
     band_dict = {band: f"mag_{band}_lsst" for band in bands}
     rename_dict = {f"{band}_err": f"mag_err_{band}_lsst" for band in bands}
@@ -323,7 +323,7 @@ def test_SpecSelection_low_N_tot(data_forspec):
     )
     data_forspec = col_remapper_test(data_forspec)
 
-    degrader_zCOSMOS = SpecSelection_zCOSMOS.make_stage(N_tot=1)
+    degrader_zCOSMOS = SpecSelection_zCOSMOS.make_stage(n_tot=1)
     degrader_zCOSMOS(data_forspec)
 
     os.remove(
@@ -333,11 +333,11 @@ def test_SpecSelection_low_N_tot(data_forspec):
     )
 
 
-@pytest.mark.parametrize("N_tot, errortype", [(-1, ValueError)])
-def test_SpecSelection_bad_params(N_tot, errortype):
+@pytest.mark.parametrize("n_tot, errortype", [(-1, ValueError)])
+def test_SpecSelection_bad_params(n_tot, errortype):
     """Test bad parameters that should raise TypeError"""
     with pytest.raises(errortype):
-        SpecSelection.make_stage(N_tot=N_tot)
+        SpecSelection.make_stage(n_tot=n_tot)
 
 
 @pytest.mark.parametrize("errortype", [ValueError])
@@ -369,10 +369,10 @@ def test_ObsCondition_returns_correct_shape(data):
     os.remove(degrader.get_output(degrader.get_aliased_tag("output"), final_name=True))
 
 
-def test_ObsCondition_random_seed(data):
+def test_ObsCondition_seed(data):
     """Test control with random seeds."""
-    degrader1 = ObsCondition.make_stage(random_seed=0)
-    degrader2 = ObsCondition.make_stage(random_seed=0)
+    degrader1 = ObsCondition.make_stage(seed=0)
+    degrader2 = ObsCondition.make_stage(seed=0)
 
     # make sure setting the same seeds yields the same output
     degraded_data1 = degrader1(data).data
@@ -380,7 +380,7 @@ def test_ObsCondition_random_seed(data):
     assert degraded_data1.equals(degraded_data2)
 
     # make sure setting different seeds yields different output
-    degrader3 = ObsCondition.make_stage(random_seed=1)
+    degrader3 = ObsCondition.make_stage(seed=1)
     degraded_data3 = degrader3(data).data.to_numpy()
     assert not degraded_data1.equals(degraded_data3)
 
@@ -468,12 +468,12 @@ def test_ObsCondition_extended(data):
         "tvis": 30.0,
     }
     tot_nVis_flag = True
-    random_seed = None
+    seed = None
 
     degrader_ext = ObsCondition.make_stage(
         weight=weight,
         tot_nVis_flag=tot_nVis_flag,
-        random_seed=random_seed,
+        seed=seed,
         map_dict=map_dict,
     )
     degrader_ext(data)
@@ -486,7 +486,7 @@ def test_ObsCondition_extended(data):
 
 def test_ObsCondition_empty_map_dict(data):
     """Test control with random seeds."""
-    degrader1 = ObsCondition.make_stage(random_seed=0, map_dict={})
+    degrader1 = ObsCondition.make_stage(seed=0, map_dict={})
     degrader2 = PhoterrErrorModel()
 
     # make sure setting the same seeds yields the same output
@@ -502,7 +502,7 @@ def test_ObsCondition_empty_map_dict(data):
 def test_ObsCondition_renameDict(data_with_radec):
     """Test with renameDict included"""
     degrader1 = ObsCondition.make_stage(
-        random_seed=0,
+        seed=0,
         map_dict={
             "EBV": 0.0,
             "renameDict": {"u": "u", "ra": "ra", "dec": "dec"},
@@ -519,7 +519,7 @@ def test_ObsCondition_renameDict(data_with_radec):
 
 def test_ObsCondition_data_with_radec(data_with_radec):
     """Test with ra dec in data"""
-    degrader1 = ObsCondition.make_stage(random_seed=0, map_dict={"EBV": 0.0})
+    degrader1 = ObsCondition.make_stage(seed=0, map_dict={"EBV": 0.0})
     degraded_data1 = degrader1(data_with_radec).data
 
     os.remove(


### PR DESCRIPTION
I left off one suggestion of renaming `in HyperbolicMagnitudes and HyperbolicSmoothing change error_columns to be the Shared Parameter err_bands`, as there was no request to rename the magnitudes, just the magnitude errors, and this seems separate enough from the estimation runs that we may not want the shared params vals.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
