### PR TITLE
Tqz/add spec selectors

### DIFF
--- a/src/rail/creation/degraders/desi_selector_phy.py
+++ b/src/rail/creation/degraders/desi_selector_phy.py
@@ -63,15 +63,13 @@ class SpecSelection_DESI_Phy(Selector):
         threshold_table=Param(str, "None", msg="Filename of the threshold file")
     )
 
-    def __call__(self, sample, threshold_table, **kwargs):
+    def __call__(self, sample, **kwargs):
         """Apply the DESI physical selection to a catalog.
 
         Parameters
         ----------
         sample : table-like or PqHandle
             Input simulation catalog.
-        threshold_table : table-like or TableHandle
-            Table with columns ``z`` and ``thresh``.
 
         Returns
         -------
@@ -81,7 +79,6 @@ class SpecSelection_DESI_Phy(Selector):
             ``flag`` column (when ``drop_rows=False``).
         """
         self.set_data("input", sample)
-        self.set_data("threshold_table", threshold_table)
         self.run()
         self.finalize()
         return self.get_handle("output")

--- a/src/rail/creation/degraders/desi_selector_phy.py
+++ b/src/rail/creation/degraders/desi_selector_phy.py
@@ -5,6 +5,7 @@ from ceci.config import StageParameter as Param
 from rail.core.data import PqHandle, TableHandle
 from rail.creation.selector import Selector
 from scipy.interpolate import interp1d
+import pandas as pd
 
 
 class SpecSelection_DESI_Phy(Selector):
@@ -38,7 +39,7 @@ class SpecSelection_DESI_Phy(Selector):
     entrypoint_function = "__call__"
     interactive_function = "spec_selection_desi_phy"
 
-    inputs = [("input", PqHandle), ("threshold_table", TableHandle)]
+    inputs = [("input", PqHandle)]
     outputs = [("output", PqHandle)]
 
     config_options = Selector.config_options.copy()
@@ -50,7 +51,7 @@ class SpecSelection_DESI_Phy(Selector):
         ),
         threshold_col=Param(
             str,
-            required=True,
+            "None",
             msg="Column in the input catalog used for threshold-based selection "
                 "(e.g. 'log_peak_sub_halo_mass' for bgs/lrg, 'log_sfr' for elg)",
         ),
@@ -59,6 +60,7 @@ class SpecSelection_DESI_Phy(Selector):
             "redshift",
             msg="Column name for redshift in the input catalog",
         ),
+        threshold_table=Param(str, "None", msg="Filename of the threshold file")
     )
 
     def __call__(self, sample, threshold_table, **kwargs):
@@ -93,10 +95,13 @@ class SpecSelection_DESI_Phy(Selector):
             Array of 0/1 flags, one per row of the input catalog.
         """
         data = self.get_data("input", allow_missing=True)
-        thresh_data = self.get_data("threshold_table", allow_missing=True)
+        # thresh_data = self.get_data("threshold_table", allow_missing=True)
 
         threshold_col = self.config.threshold_col
         redshift_col = self.config.redshift_col
+
+        threshold_table = self.config.threshold_table
+        thresh_data = pd.read_parquet(threshold_table)
 
         # --- validate input columns ---
         for col in (threshold_col, redshift_col):

--- a/src/rail/creation/degraders/desi_selector_phy.py
+++ b/src/rail/creation/degraders/desi_selector_phy.py
@@ -100,7 +100,7 @@ class SpecSelection_DESI_Phy(Selector):
         threshold_table = self.config.threshold_table
         try:
             thresh_data = pd.read_parquet(threshold_table)
-        except Exception as e:
+        except Exception as e: # pragma: no cover
             raise ValueError(
                 f"Could not read threshold file '{threshold_table}' as a Parquet file. "
                 f"Ensure the file exists and is a valid Parquet file. Original error: {e}"

--- a/src/rail/creation/degraders/desi_selector_phy.py
+++ b/src/rail/creation/degraders/desi_selector_phy.py
@@ -98,7 +98,13 @@ class SpecSelection_DESI_Phy(Selector):
         redshift_col = self.config.redshift_col
 
         threshold_table = self.config.threshold_table
-        thresh_data = pd.read_parquet(threshold_table)
+        try:
+            thresh_data = pd.read_parquet(threshold_table)
+        except Exception as e:
+            raise ValueError(
+                f"Could not read threshold file '{threshold_table}' as a Parquet file. "
+                f"Ensure the file exists and is a valid Parquet file. Original error: {e}"
+            ) from e
 
         # --- validate input columns ---
         for col in (threshold_col, redshift_col):

--- a/src/rail/pipelines/degradation/spectroscopic_selection_pipeline.py
+++ b/src/rail/pipelines/degradation/spectroscopic_selection_pipeline.py
@@ -33,6 +33,26 @@ SELECTORS = dict(
         Select="SpecSelection_HSC",
         Module="rail.creation.degraders.spectroscopic_selections",
     ),
+    DEEP2_LSST=dict(
+        Select="SpecSelection_DEEP2_LSST",
+        Module="rail.creation.degraders.spectroscopic_selections",
+    ),
+    DESI_BGS=dict(
+        Select="SpecSelection_DESI_BGS",
+        Module="rail.creation.degraders.spectroscopic_selections",
+    ),
+    DESI_LRG=dict(
+        Select="SpecSelection_DESI_LRG",
+        Module="rail.creation.degraders.spectroscopic_selections",
+    ),
+    DESI_ELG_LOP=dict(
+        Select="SpecSelection_DESI_ELG_LOP",
+        Module="rail.creation.degraders.spectroscopic_selections",
+    ),
+    DESI_LRG_phys=dict(
+        Select="SpecSelection_DESI_Phy",
+        Module="rail.creation.degraders.desi_selector_phy",
+    )
 )
 
 

--- a/src/rail/pipelines/degradation/truth_to_observed.py
+++ b/src/rail/pipelines/degradation/truth_to_observed.py
@@ -132,6 +132,22 @@ class TruthToObservedPipeline(RailPipeline):
                 config_pars,
             )
 
+    # def _add_selectors(
+    #     self,
+    #     previous_stage,
+    #     key: str,
+    #     selectors: dict,
+    #     config_pars: dict,
+    # ) -> None:
+
+    #     for keyS, valS in selectors.items():
+    #         the_class = ceci.PipelineStage.get_stage(valS["Select"], valS["Module"])
+    #         the_selector = the_class.make_and_connect(
+    #             name=f"select_{key}_{keyS}",
+    #             connections=dict(input=previous_stage.io.output),
+    #             **config_pars,
+    #         )
+    #         self.add_stage(the_selector)
     def _add_selectors(
         self,
         previous_stage,
@@ -142,9 +158,11 @@ class TruthToObservedPipeline(RailPipeline):
 
         for keyS, valS in selectors.items():
             the_class = ceci.PipelineStage.get_stage(valS["Select"], valS["Module"])
+            overrides = valS.get("Overrides", {})
             the_selector = the_class.make_and_connect(
                 name=f"select_{key}_{keyS}",
                 connections=dict(input=previous_stage.io.output),
                 **config_pars,
+                **overrides,
             )
             self.add_stage(the_selector)

--- a/src/rail/pipelines/degradation/truth_to_observed.py
+++ b/src/rail/pipelines/degradation/truth_to_observed.py
@@ -132,22 +132,6 @@ class TruthToObservedPipeline(RailPipeline):
                 config_pars,
             )
 
-    # def _add_selectors(
-    #     self,
-    #     previous_stage,
-    #     key: str,
-    #     selectors: dict,
-    #     config_pars: dict,
-    # ) -> None:
-
-    #     for keyS, valS in selectors.items():
-    #         the_class = ceci.PipelineStage.get_stage(valS["Select"], valS["Module"])
-    #         the_selector = the_class.make_and_connect(
-    #             name=f"select_{key}_{keyS}",
-    #             connections=dict(input=previous_stage.io.output),
-    #             **config_pars,
-    #         )
-    #         self.add_stage(the_selector)
     def _add_selectors(
         self,
         previous_stage,

--- a/tests/astro_tools/test_desi_selector_phy.py
+++ b/tests/astro_tools/test_desi_selector_phy.py
@@ -29,17 +29,30 @@ def catalog():
 
 
 @pytest.fixture
-def threshold_table():
-    """Flat threshold of 12.0 across the full redshift range."""
+def threshold_parquet(tmp_path):
+    """Flat threshold of 12.0 across the full redshift range, written to disk."""
     df = pd.DataFrame({"z": [0.0, 0.5, 1.0], "thresh": [12.0, 12.0, 12.0]})
-    return TableHandle("threshold_table", df, path="dummy_thresh.pq")
+    path = str(tmp_path / "thresh.parquet")
+    df.to_parquet(path)
+    return path
 
 
 @pytest.fixture
-def varying_threshold_table():
-    """Threshold that rises linearly from 11.0 at z=0 to 13.0 at z=1."""
+def varying_threshold_parquet(tmp_path):
+    """Threshold rising linearly from 11.0 at z=0 to 13.0 at z=1, written to disk."""
     df = pd.DataFrame({"z": [0.0, 1.0], "thresh": [11.0, 13.0]})
-    return TableHandle("varying_threshold_table", df, path="dummy_varying_thresh.pq")
+    path = str(tmp_path / "varying_thresh.parquet")
+    df.to_parquet(path)
+    return path
+
+
+@pytest.fixture
+def bad_threshold_parquet(tmp_path):
+    """Threshold table with wrong column names, written to disk."""
+    df = pd.DataFrame({"redshift": [0.0, 1.0], "value": [12.0, 12.0]})
+    path = str(tmp_path / "bad_thresh.parquet")
+    df.to_parquet(path)
+    return path
 
 
 # ---------------------------------------------------------------------------
@@ -58,15 +71,16 @@ def _cleanup(stage):
 # ---------------------------------------------------------------------------
 
 
-def test_basic_selection_correct_rows(catalog, threshold_table):
+def test_basic_selection_correct_rows(catalog, threshold_parquet):
     """Objects with log_peak_sub_halo_mass > 12.0 should be selected."""
     sel = SpecSelection_DESI_Phy.make_stage(
         name="test_basic",
         desi_type="lrg",
         threshold_col="log_peak_sub_halo_mass",
+        threshold_table=threshold_parquet,
         drop_rows=True,
     )
-    result = sel(catalog, threshold_table).data
+    result = sel(catalog).data
 
     # All selected rows must have the physical column above the threshold
     assert (result["log_peak_sub_halo_mass"] > 12.0).all()
@@ -77,29 +91,31 @@ def test_basic_selection_correct_rows(catalog, threshold_table):
     _cleanup(sel)
 
 
-def test_output_has_same_columns(catalog, threshold_table):
+def test_output_has_same_columns(catalog, threshold_parquet):
     """Output catalog should have the same columns as the input."""
     sel = SpecSelection_DESI_Phy.make_stage(
         name="test_cols",
         desi_type="lrg",
         threshold_col="log_peak_sub_halo_mass",
+        threshold_table=threshold_parquet,
         drop_rows=True,
     )
-    result = sel(catalog, threshold_table).data
+    result = sel(catalog).data
 
     assert set(result.columns) == set(catalog.data.columns)
     _cleanup(sel)
 
 
-def test_drop_rows_false_returns_flag_column(catalog, threshold_table):
+def test_drop_rows_false_returns_flag_column(catalog, threshold_parquet):
     """With drop_rows=False all rows are returned with a 'flag' column."""
     sel = SpecSelection_DESI_Phy.make_stage(
         name="test_flag",
         desi_type="lrg",
         threshold_col="log_peak_sub_halo_mass",
+        threshold_table=threshold_parquet,
         drop_rows=False,
     )
-    result = sel(catalog, threshold_table).data
+    result = sel(catalog).data
 
     assert len(result) == len(catalog.data)
     assert "flag" in result.columns
@@ -109,15 +125,16 @@ def test_drop_rows_false_returns_flag_column(catalog, threshold_table):
     _cleanup(sel)
 
 
-def test_varying_threshold_selection(catalog, varying_threshold_table):
+def test_varying_threshold_selection(catalog, varying_threshold_parquet):
     """Verify selection respects a redshift-varying threshold via interpolation."""
     sel = SpecSelection_DESI_Phy.make_stage(
         name="test_varying",
         desi_type="lrg",
         threshold_col="log_peak_sub_halo_mass",
+        threshold_table=varying_threshold_parquet,
         drop_rows=False,
     )
-    result = sel(catalog, varying_threshold_table).data
+    result = sel(catalog).data
 
     # Recompute expected mask manually
     from scipy.interpolate import interp1d
@@ -133,59 +150,58 @@ def test_varying_threshold_selection(catalog, varying_threshold_table):
 
 
 @pytest.mark.parametrize("desi_type", ["bgs", "lrg", "elg"])
-def test_desi_types_run_without_error(catalog, threshold_table, desi_type):
+def test_desi_types_run_without_error(catalog, threshold_parquet, desi_type):
     """All supported desi_type values should produce a valid output."""
     sel = SpecSelection_DESI_Phy.make_stage(
         name=f"test_{desi_type}",
         desi_type=desi_type,
         threshold_col="log_peak_sub_halo_mass",
+        threshold_table=threshold_parquet,
         drop_rows=True,
     )
-    result = sel(catalog, threshold_table).data
+    result = sel(catalog).data
     assert isinstance(result, pd.DataFrame)
     _cleanup(sel)
 
 
-def test_missing_threshold_col_raises(catalog, threshold_table):
+def test_missing_threshold_col_raises(catalog, threshold_parquet):
     """ValueError raised when the specified threshold_col is absent from catalog."""
     sel = SpecSelection_DESI_Phy.make_stage(
         name="test_missing_col",
         desi_type="lrg",
         threshold_col="nonexistent_column",
+        threshold_table=threshold_parquet,
     )
     with pytest.raises(ValueError, match="nonexistent_column"):
-        sel(catalog, threshold_table)
+        sel(catalog)
 
 
-def test_missing_redshift_col_raises(catalog, threshold_table):
+def test_missing_redshift_col_raises(catalog, threshold_parquet):
     """ValueError raised when the specified redshift_col is absent from catalog."""
     sel = SpecSelection_DESI_Phy.make_stage(
         name="test_missing_z",
         desi_type="lrg",
         threshold_col="log_peak_sub_halo_mass",
         redshift_col="nonexistent_redshift",
+        threshold_table=threshold_parquet,
     )
     with pytest.raises(ValueError, match="nonexistent_redshift"):
-        sel(catalog, threshold_table)
+        sel(catalog)
 
 
-def test_missing_thresh_table_columns_raises(catalog):
+def test_missing_thresh_table_columns_raises(catalog, bad_threshold_parquet):
     """ValueError raised when the threshold table lacks 'z' or 'thresh'."""
-    bad_thresh = TableHandle(
-        "bad_thresh",
-        pd.DataFrame({"redshift": [0.0, 1.0], "value": [12.0, 12.0]}),
-        path="dummy_bad.pq",
-    )
     sel = SpecSelection_DESI_Phy.make_stage(
         name="test_bad_thresh",
         desi_type="lrg",
         threshold_col="log_peak_sub_halo_mass",
+        threshold_table=bad_threshold_parquet,
     )
     with pytest.raises(ValueError, match="z"):
-        sel(catalog, bad_thresh)
+        sel(catalog)
 
 
-def test_flat_threshold_selects_nothing_when_all_below(threshold_table):
+def test_flat_threshold_selects_nothing_when_all_below(threshold_parquet):
     """When all physical values are below the threshold nothing is selected."""
     df = pd.DataFrame(
         {
@@ -199,14 +215,15 @@ def test_flat_threshold_selects_nothing_when_all_below(threshold_table):
         name="test_none_selected",
         desi_type="lrg",
         threshold_col="log_peak_sub_halo_mass",
+        threshold_table=threshold_parquet,
         drop_rows=True,
     )
-    result = sel(cat, threshold_table).data
+    result = sel(cat).data
     assert len(result) == 0
     _cleanup(sel)
 
 
-def test_flat_threshold_selects_all_when_all_above(threshold_table):
+def test_flat_threshold_selects_all_when_all_above(threshold_parquet):
     """When all physical values are above the threshold everything is selected."""
     df = pd.DataFrame(
         {
@@ -220,8 +237,9 @@ def test_flat_threshold_selects_all_when_all_above(threshold_table):
         name="test_all_selected",
         desi_type="lrg",
         threshold_col="log_peak_sub_halo_mass",
+        threshold_table=threshold_parquet,
         drop_rows=True,
     )
-    result = sel(cat, threshold_table).data
+    result = sel(cat).data
     assert len(result) == len(df)
     _cleanup(sel)


### PR DESCRIPTION
1. DESI selector use configuration to read in threshold file, which makes it easier to parallelize with other selectors
2. Add more selectors to the list of spectroscopic_selection_pipeline
3. Allow config overrides for SpecSelectors


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
